### PR TITLE
Dev

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 name: Release
 
-# Runs on every push to main/master (and PRs for lint+build smoke test).
+# Runs ONLY on direct pushes to main/master (not PRs).
 # Single workflow: lint → read version → tag (if new) → build & push.
 # This avoids the GitHub Actions limitation where a GITHUB_TOKEN-pushed
 # tag cannot trigger a separate workflow.
@@ -13,8 +13,6 @@ on:
       - "client/**"
       - "Dockerfile"
       - ".github/workflows/release.yml"
-  pull_request:
-    branches: [main, master]
   workflow_dispatch:
     inputs:
       push_image:

--- a/Readme.md
+++ b/Readme.md
@@ -22,13 +22,15 @@ A self-hosted machine learning platform — upload datasets, wrangle data, train
 ## Features
 
 - 📁 **Dataset management** — upload CSV / Excel files, version datasets, explore stats, wrangle (normalise, encode, drop nulls)
+- 📊 **Rich statistics** — per-column descriptive stats (count, mean, std, quartiles) + Pearson correlation heatmap
 - 🤖 **Model training** — train scikit-learn models (classifiers & regressors) with configurable hyperparameters loaded live from the library
 - 🔁 **Retraining & versioning** — retrain any model to create a new version with full lineage tracking
-- 🧪 **In-browser testing** — run single-row predictions directly from the UI
+- 🧪 **In-browser testing** — run single-row predictions directly from the UI (Sheet sidebar, not a blocking dialog)
 - ⬇️ **Model download** — download trained `.joblib` files for use outside the platform
-- 📊 **Dashboard** — live stats: model count, dataset count, accuracy distribution, storage usage
+- 📈 **Dashboard** — live stats: model count, dataset count, accuracy distribution, storage usage
 - 🌙 **Dark / Light / System theme**
 - 🔐 **JWT authentication** — cookie-based, HTTPOnly
+- 🛡️ **Deployment controls** — disable public signup + seed a default admin via environment variables
 
 ---
 
@@ -53,6 +55,32 @@ docker run -d \
 ```
 
 Open **http://localhost:8000** — UI and API both served from the same port.
+
+### Environment Variables
+
+All variables are optional — the defaults work immediately. Pass them with `-e` to `docker run` or in a `docker-compose.yml`.
+
+| Variable | Default | Description |
+|---|---|---|
+| `JWT_SECRET` | `development` | **Set this to a secret value in production** |
+| `DISABLE_SIGNUP` | `False` | `True` to hide the Sign Up tab and block the endpoint |
+| `DEFAULT_ADMIN_EMAIL` | _(none)_ | Auto-create an admin on first boot |
+| `DEFAULT_ADMIN_PASSWORD` | _(none)_ | Password for the auto-created admin |
+
+Example with a locked-down admin-only instance:
+
+```bash
+docker run -d \
+  -p 8000:8000 \
+  -v mlcore-db:/data \
+  -v mlcore-uploads:/app/server/uploads \
+  -e JWT_SECRET=my-super-secret \
+  -e DISABLE_SIGNUP=True \
+  -e DEFAULT_ADMIN_EMAIL=admin@mycompany.com \
+  -e DEFAULT_ADMIN_PASSWORD=StrongP@ssw0rd! \
+  --name mlcore \
+  procoder588/mlcore:latest
+```
 
 ### Volumes
 

--- a/client/README.md
+++ b/client/README.md
@@ -86,10 +86,10 @@ src/
 │   ├── api.ts       Axios instance (baseURL = /api)
 │   └── utils.ts     cn() and other helpers
 ├── pages/
-│   ├── AuthPage.tsx
+│   ├── AuthPage.tsx        Login + conditional Sign Up (hidden via server config)
 │   ├── DashboardPage.tsx
-│   ├── DatasetsPage.tsx
-│   ├── ModelsPage.tsx
+│   ├── DatasetsPage.tsx    Dataset explorer with descriptive stats & correlation heatmap
+│   ├── ModelsPage.tsx      Model train / retrain / predict (Sheet-based sidebar UX)
 │   └── SettingsPage.tsx
 └── store/
     └── auth.ts      Zustand auth store
@@ -127,3 +127,18 @@ npm run format
 ```
 
 Configuration is in `biome.json`.
+
+---
+
+## Key Features
+
+### Dynamic Auth
+`AuthPage.tsx` fetches `GET /api/auth/config` on mount. If the server has `DISABLE_SIGNUP=True` set, the Sign Up tab is hidden automatically — no client-side config changes needed.
+
+### Dataset Explorer
+`DatasetsPage.tsx` sidebar includes:
+- **Descriptive statistics table** — count, mean, std, min, 25%, 50%, 75%, max for every numeric column.
+- **Correlation heatmap** — colour-coded matrix (green = positive, red = negative) computed via Pandas `df.corr()` on the backend.
+
+### Model Workflows
+`ModelsPage.tsx` uses `Sheet` sidebars (not Dialogs) for Train, Retrain, and Predict so the workspace stays persistent and non-blocking.

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "client",
-	"version": "0.1.4",
+	"version": "0.1.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "client",
-			"version": "0.1.4",
+			"version": "0.1.5",
 			"dependencies": {
 				"@base-ui/react": "^1.2.0",
 				"@tailwindcss/vite": "^4.2.0",

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "client",
 	"private": true,
-	"version": "0.1.4",
+	"version": "0.1.5",
 	"type": "module",
 	"scripts": {
 		"dev": "vite",

--- a/client/src/pages/AuthPage.tsx
+++ b/client/src/pages/AuthPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useAuthStore } from "@/store/auth";
 import { api } from "@/lib/api";
 import { useNavigate } from "react-router-dom";
@@ -114,6 +114,17 @@ export function AuthPage() {
 	const [isLoading, setIsLoading] = useState(false);
 	const [showLoginPw, setShowLoginPw] = useState(false);
 	const [showSignupPw, setShowSignupPw] = useState(false);
+	const [disableSignup, setDisableSignup] = useState(false);
+
+	useEffect(() => {
+		api.get("/auth/config")
+			.then((res) => {
+				setDisableSignup(res.data.disable_signup);
+			})
+			.catch(() => {
+				// Defaults to false on network error
+			});
+	}, []);
 
 	const [loginData, setLoginData] = useState({ email: "", password: "" });
 	const [loginErrors, setLoginErrors] = useState({ email: "", password: "" });
@@ -215,9 +226,9 @@ export function AuthPage() {
 					</div>
 
 					<Tabs defaultValue="login" className="w-full">
-						<TabsList className="grid w-full grid-cols-2">
+						<TabsList className={`grid w-full ${disableSignup ? "grid-cols-1" : "grid-cols-2"}`}>
 							<TabsTrigger value="login">Login</TabsTrigger>
-							<TabsTrigger value="signup">Sign Up</TabsTrigger>
+							{!disableSignup && <TabsTrigger value="signup">Sign Up</TabsTrigger>}
 						</TabsList>
 
 						{/* ── Login ── */}

--- a/client/src/pages/AuthPage.tsx
+++ b/client/src/pages/AuthPage.tsx
@@ -117,7 +117,8 @@ export function AuthPage() {
 	const [disableSignup, setDisableSignup] = useState(false);
 
 	useEffect(() => {
-		api.get("/auth/config")
+		api
+			.get("/auth/config")
 			.then((res) => {
 				setDisableSignup(res.data.disable_signup);
 			})
@@ -226,9 +227,13 @@ export function AuthPage() {
 					</div>
 
 					<Tabs defaultValue="login" className="w-full">
-						<TabsList className={`grid w-full ${disableSignup ? "grid-cols-1" : "grid-cols-2"}`}>
+						<TabsList
+							className={`grid w-full ${disableSignup ? "grid-cols-1" : "grid-cols-2"}`}
+						>
 							<TabsTrigger value="login">Login</TabsTrigger>
-							{!disableSignup && <TabsTrigger value="signup">Sign Up</TabsTrigger>}
+							{!disableSignup && (
+								<TabsTrigger value="signup">Sign Up</TabsTrigger>
+							)}
 						</TabsList>
 
 						{/* ── Login ── */}

--- a/client/src/pages/AuthPage.tsx
+++ b/client/src/pages/AuthPage.tsx
@@ -194,15 +194,16 @@ export function AuthPage() {
 	};
 
 	return (
-		<div className="min-h-screen grid lg:grid-cols-2">
-			<div className="flex flex-col justify-center p-8 sm:p-12 md:p-16 relative">
-				<div className="absolute top-8 left-8 flex items-center gap-2">
-					<div className="bg-primary/20 border border-primary/30 p-1.5 rounded-lg">
-						<Activity className="w-4 h-4 text-primary" />
-					</div>
-					<span className="font-bold text-sm">ML Core</span>
+		<div className="min-h-screen flex items-center justify-center bg-background relative">
+			{/* Brand Logo - Top Left */}
+			<div className="absolute top-8 left-8 flex items-center gap-2">
+				<div className="bg-primary/20 border border-primary/30 p-1.5 rounded-lg">
+					<Activity className="w-4 h-4 text-primary" />
 				</div>
+				<span className="font-bold text-sm">ML Core</span>
+			</div>
 
+			<div className="flex flex-col justify-center p-8 sm:p-12 md:p-16 relative w-full max-w-2xl">
 				<div className="mx-auto w-full max-w-md space-y-6">
 					<div className="space-y-2 text-center">
 						<h1 className="text-3xl font-bold tracking-tight">
@@ -456,25 +457,6 @@ export function AuthPage() {
 						</TabsContent>
 					</Tabs>
 				</div>
-			</div>
-
-			<div className="hidden lg:block relative bg-muted h-full overflow-hidden">
-				<picture>
-					<source
-						srcSet="/front_image_dark.png"
-						media="(prefers-color-scheme: dark)"
-					/>
-					<source
-						srcSet="/front_image_light.png"
-						media="(prefers-color-scheme: light)"
-					/>
-					<img
-						src="/front_image_light.png"
-						alt="ML Core preview"
-						className="absolute inset-0 w-full h-full object-cover object-center"
-					/>
-				</picture>
-				<div className="absolute inset-x-0 bottom-0 h-1/3 bg-gradient-to-t from-background/60 to-transparent z-10" />
 			</div>
 		</div>
 	);

--- a/client/src/pages/DatasetsPage.tsx
+++ b/client/src/pages/DatasetsPage.tsx
@@ -107,12 +107,17 @@ const CLEAN_STRATEGIES = [
 	{ value: "drop_nulls", label: "Drop Nulls" },
 	{ value: "fill_mean", label: "Fill with Mean" },
 	{ value: "fill_median", label: "Fill with Median" },
+	{ value: "fill_mode", label: "Fill with Mode" },
+	{ value: "drop_columns", label: "Drop Columns" },
+	{ value: "remove_outliers_iqr", label: "Remove Outliers (IQR)" },
 ];
 
 const TRANSFORM_STRATEGIES = [
 	{ value: "standard_scaler", label: "Standard Scaler" },
 	{ value: "min_max_scaler", label: "Min-Max Scaler" },
 	{ value: "label_encoder", label: "Label Encoder" },
+	{ value: "one_hot_encoder", label: "One-Hot Encoder (Dummies)" },
+	{ value: "log_transform", label: "Log1p Transform" },
 ];
 
 export function DatasetsPage() {
@@ -285,6 +290,10 @@ export function DatasetsPage() {
 
 	const handleClean = async () => {
 		if (!wrangleDs) return;
+		if (cleanStrategy === "drop_columns" && cleanCols.length === 0) {
+			toast.error("Select at least one column to drop");
+			return;
+		}
 		try {
 			setIsWrangling(true);
 			await api.post(`/dataset/${wrangleDs.id}/clean`, {
@@ -303,9 +312,11 @@ export function DatasetsPage() {
 
 	const handleTransform = async () => {
 		if (!wrangleDs) return;
-		// For label_encoder, require explicit column selection
-		if (transformStrategy === "label_encoder" && transformCols.length === 0) {
-			toast.error("Select at least one column to label encode");
+		if (
+			(transformStrategy === "label_encoder" || transformStrategy === "one_hot_encoder") &&
+			transformCols.length === 0
+		) {
+			toast.error("Select at least one column to encode");
 			return;
 		}
 		const meta = wrangleDs.dataset_metadata;

--- a/client/src/pages/DatasetsPage.tsx
+++ b/client/src/pages/DatasetsPage.tsx
@@ -86,6 +86,7 @@ interface DatasetMeta {
 	missing_values?: Record<string, number>;
 	missing_percentage?: Record<string, number>;
 	statistics?: Record<string, Record<string, number>>;
+	correlation?: Record<string, Record<string, number>>;
 	preview?: Record<string, unknown>[];
 }
 
@@ -315,7 +316,8 @@ export function DatasetsPage() {
 	const handleTransform = async () => {
 		if (!explorerDs) return;
 		if (
-			(transformStrategy === "label_encoder" || transformStrategy === "one_hot_encoder") &&
+			(transformStrategy === "label_encoder" ||
+				transformStrategy === "one_hot_encoder") &&
 			transformCols.length === 0
 		) {
 			toast.error("Select at least one column to encode");
@@ -357,7 +359,9 @@ export function DatasetsPage() {
 			const fetchData = async () => {
 				setLoading(true);
 				try {
-					const res = await api.get(`/dataset/${ds.id}/data?page=${page}&limit=${limit}`);
+					const res = await api.get(
+						`/dataset/${ds.id}/data?page=${page}&limit=${limit}`,
+					);
 					if (isMounted) {
 						setData(res.data.data);
 						setTotalRows(res.data.total_rows);
@@ -370,7 +374,9 @@ export function DatasetsPage() {
 				}
 			};
 			fetchData();
-			return () => { isMounted = false; };
+			return () => {
+				isMounted = false;
+			};
 		}, [ds.id, page]);
 
 		const dtypes = ds.dataset_metadata?.dtypes ?? {};
@@ -378,7 +384,11 @@ export function DatasetsPage() {
 		const cols = Object.keys(dtypes);
 
 		if (loading && data.length === 0) {
-			return <div className="flex justify-center p-8"><Loader2 className="w-6 h-6 animate-spin text-muted-foreground" /></div>;
+			return (
+				<div className="flex justify-center p-8">
+					<Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
+				</div>
+			);
 		}
 
 		if (!loading && data.length === 0)
@@ -422,13 +432,30 @@ export function DatasetsPage() {
 						</tbody>
 					</table>
 				</div>
-                <div className="flex items-center justify-between text-sm">
-                    <span className="text-muted-foreground">Showing {(page-1)*limit + 1} to {Math.min(page*limit, totalRows)} of {totalRows} rows</span>
-                    <div className="flex gap-2">
-                        <Button variant="outline" size="sm" onClick={() => setPage(page - 1)} disabled={page <= 1 || loading}>Previous</Button>
-                        <Button variant="outline" size="sm" onClick={() => setPage(page + 1)} disabled={page >= totalPages || loading}>Next</Button>
-                    </div>
-                </div>
+				<div className="flex items-center justify-between text-sm">
+					<span className="text-muted-foreground">
+						Showing {(page - 1) * limit + 1} to{" "}
+						{Math.min(page * limit, totalRows)} of {totalRows} rows
+					</span>
+					<div className="flex gap-2">
+						<Button
+							variant="outline"
+							size="sm"
+							onClick={() => setPage(page - 1)}
+							disabled={page <= 1 || loading}
+						>
+							Previous
+						</Button>
+						<Button
+							variant="outline"
+							size="sm"
+							onClick={() => setPage(page + 1)}
+							disabled={page >= totalPages || loading}
+						>
+							Next
+						</Button>
+					</div>
+				</div>
 				{cols.some((c) => (missing[c] ?? 0) > 0) && (
 					<div className="p-3 border rounded-lg bg-muted/20 space-y-1">
 						<p className="text-xs font-medium text-muted-foreground mb-2">
@@ -665,7 +692,10 @@ export function DatasetsPage() {
 										</DropdownMenuItem>
 										<DropdownMenuItem
 											className="gap-2"
-											onClick={() => { setExplorerDs(ds); setExplorerTab("wrangle"); }}
+											onClick={() => {
+												setExplorerDs(ds);
+												setExplorerTab("wrangle");
+											}}
 										>
 											<Wand2 className="w-4 h-4" /> Wrangle
 										</DropdownMenuItem>
@@ -760,7 +790,10 @@ export function DatasetsPage() {
 									variant="ghost"
 									size="sm"
 									className="flex-1 gap-2 text-muted-foreground hover:text-primary"
-									onClick={() => { setExplorerDs(ds); setExplorerTab("wrangle"); }}
+									onClick={() => {
+										setExplorerDs(ds);
+										setExplorerTab("wrangle");
+									}}
 								>
 									<Wand2 className="w-4 h-4" /> Wrangle
 								</Button>
@@ -899,10 +932,7 @@ export function DatasetsPage() {
 									{[...versions]
 										.sort((a, b) => a.version.localeCompare(b.version))
 										.map((v) => (
-											<div
-												key={v.id}
-												className="relative pl-6"
-											>
+											<div key={v.id} className="relative pl-6">
 												{/* Connecting dot */}
 												<div className="absolute w-3.5 h-3.5 bg-primary/80 rounded-full -left-[8px] top-4 ring-4 ring-background" />
 
@@ -930,9 +960,17 @@ export function DatasetsPage() {
 													</div>
 													<p className="text-sm font-semibold">{v.name}</p>
 													<div className="flex items-center gap-3 text-xs text-muted-foreground">
-														<span className="flex items-center gap-1"><BarChart3 className="w-3 h-3"/> {v.rows.toLocaleString()}</span>
-														<span className="flex items-center gap-1"><Filter className="w-3 h-3"/> {v.columns}</span>
-														<span className="flex items-center gap-1"><Sigma className="w-3 h-3"/> {v.file?.file_type?.toUpperCase() ?? "—"}</span>
+														<span className="flex items-center gap-1">
+															<BarChart3 className="w-3 h-3" />{" "}
+															{v.rows.toLocaleString()}
+														</span>
+														<span className="flex items-center gap-1">
+															<Filter className="w-3 h-3" /> {v.columns}
+														</span>
+														<span className="flex items-center gap-1">
+															<Sigma className="w-3 h-3" />{" "}
+															{v.file?.file_type?.toUpperCase() ?? "—"}
+														</span>
 													</div>
 												</div>
 											</div>
@@ -954,266 +992,223 @@ export function DatasetsPage() {
 						<>
 							<div className="flex-1 overflow-y-auto overflow-x-hidden pr-2 space-y-6">
 								<SheetHeader className="mb-2">
-								<SheetTitle className="flex items-center gap-2">
-									<Database className="w-5 h-5" />
-									{explorerDs.name}
-									<Badge variant="secondary" className="font-mono text-xs">
-										v{explorerDs.version}
-									</Badge>
-								</SheetTitle>
-								<SheetDescription>{explorerDs.description}</SheetDescription>
-							</SheetHeader>
+									<SheetTitle className="flex items-center gap-2">
+										<Database className="w-5 h-5" />
+										{explorerDs.name}
+										<Badge variant="secondary" className="font-mono text-xs">
+											v{explorerDs.version}
+										</Badge>
+									</SheetTitle>
+									<SheetDescription>{explorerDs.description}</SheetDescription>
+								</SheetHeader>
 
-							{/* Stats row */}
-							<div className="grid grid-cols-3 gap-3 mb-4">
-								{[
-									{
-										icon: BarChart3,
-										label: "Rows",
-										value: explorerDs.rows.toLocaleString(),
-									},
-									{ icon: Filter, label: "Columns", value: explorerDs.columns },
-									{
-										icon: Sigma,
-										label: "File type",
-										value: explorerDs.file?.file_type?.toUpperCase() ?? "—",
-									},
-								].map(({ icon: Icon, label, value }) => (
-									<div
-										key={label}
-										className="rounded-lg bg-muted/50 p-3 text-center"
-									>
-										<Icon className="w-4 h-4 mx-auto text-muted-foreground mb-1" />
-										<p className="text-xs text-muted-foreground">{label}</p>
-										<p className="font-semibold text-sm">{value}</p>
-									</div>
-								))}
-							</div>
-
-							{/* Tabs: Preview / Columns / Stats / Wrangle */}
-							<Tabs value={explorerTab} onValueChange={setExplorerTab}>
-								<TabsList className="mb-3 w-full">
-									<TabsTrigger value="preview" className="flex-1">
-										Preview
-									</TabsTrigger>
-									<TabsTrigger value="columns" className="flex-1">
-										Columns
-									</TabsTrigger>
-									<TabsTrigger value="stats" className="flex-1">
-										Statistics
-									</TabsTrigger>
-									<TabsTrigger value="wrangle" className="flex-1">
-										Wrangle
-									</TabsTrigger>
-								</TabsList>
-
-								<TabsContent value="preview">
-									<PreviewTable ds={explorerDs} />
-								</TabsContent>
-
-								<TabsContent value="columns">
-									{explorerDs.dataset_metadata?.dtypes ? (
-										<div className="rounded-lg border overflow-auto">
-											<table className="min-w-full text-sm">
-												<thead className="bg-muted/60">
-													<tr>
-														<th className="px-4 py-2 text-left font-semibold border-b">
-															Column
-														</th>
-														<th className="px-4 py-2 text-left font-semibold border-b">
-															Type
-														</th>
-														<th className="px-4 py-2 text-left font-semibold border-b">
-															Missing
-														</th>
-													</tr>
-												</thead>
-												<tbody>
-													{Object.entries(
-														explorerDs.dataset_metadata.dtypes,
-													).map(([col, dtype]) => {
-														const pct =
-															explorerDs.dataset_metadata.missing_percentage?.[
-																col
-															] ?? 0;
-														return (
-															<tr
-																key={col}
-																className="border-b last:border-0 hover:bg-muted/30"
-															>
-																<td className="px-4 py-2 font-medium font-mono text-xs">
-																	{col}
-																</td>
-																<td className="px-4 py-2">
-																	<Badge variant="outline" className="text-xs">
-																		{dtype}
-																	</Badge>
-																</td>
-																<td className="px-4 py-2">
-																	<div className="flex items-center gap-2">
-																		<Progress
-																			value={pct}
-																			className="h-1.5 w-16"
-																		/>
-																		<span className="text-xs text-muted-foreground w-10">
-																			{pct.toFixed(1)}%
-																		</span>
-																	</div>
-																</td>
-															</tr>
-														);
-													})}
-												</tbody>
-											</table>
+								{/* Stats row */}
+								<div className="grid grid-cols-3 gap-3 mb-4">
+									{[
+										{
+											icon: BarChart3,
+											label: "Rows",
+											value: explorerDs.rows.toLocaleString(),
+										},
+										{
+											icon: Filter,
+											label: "Columns",
+											value: explorerDs.columns,
+										},
+										{
+											icon: Sigma,
+											label: "File type",
+											value: explorerDs.file?.file_type?.toUpperCase() ?? "—",
+										},
+									].map(({ icon: Icon, label, value }) => (
+										<div
+											key={label}
+											className="rounded-lg bg-muted/50 p-3 text-center"
+										>
+											<Icon className="w-4 h-4 mx-auto text-muted-foreground mb-1" />
+											<p className="text-xs text-muted-foreground">{label}</p>
+											<p className="font-semibold text-sm">{value}</p>
 										</div>
-									) : (
-										<p className="text-sm text-muted-foreground">
-											No column metadata available.
-										</p>
-									)}
-								</TabsContent>
+									))}
+								</div>
 
-								<TabsContent value="stats" className="space-y-4">
-									{(() => {
-										const stats = explorerDs.dataset_metadata?.statistics;
-										const dtypes = explorerDs.dataset_metadata?.dtypes ?? {};
-										const numericCols = Object.entries(dtypes)
-											.filter(
-												([, t]) => t.includes("int") || t.includes("float"),
-											)
-											.map(([c]) => c);
+								{/* Tabs: Preview / Columns / Stats / Wrangle */}
+								<Tabs value={explorerTab} onValueChange={setExplorerTab}>
+									<TabsList className="mb-3 w-full">
+										<TabsTrigger value="preview" className="flex-1">
+											Preview
+										</TabsTrigger>
+										<TabsTrigger value="columns" className="flex-1">
+											Columns
+										</TabsTrigger>
+										<TabsTrigger value="stats" className="flex-1">
+											Statistics
+										</TabsTrigger>
+										<TabsTrigger value="wrangle" className="flex-1">
+											Wrangle
+										</TabsTrigger>
+									</TabsList>
 
-										if (!stats || numericCols.length === 0) {
-											return (
-												<p className="text-sm text-muted-foreground text-center py-8">
-													No numeric columns found. Refresh metadata to compute
-													statistics.
-												</p>
-											);
-										}
+									<TabsContent value="preview">
+										<PreviewTable ds={explorerDs} />
+									</TabsContent>
 
-										// Missing values bar chart data
-										const missingData = Object.entries(
-											explorerDs.dataset_metadata.missing_percentage ?? {},
-										)
-											.filter(([, v]) => v > 0)
-											.map(([col, val]) => ({
-												col: col.length > 10 ? `${col.slice(0, 10)}…` : col,
-												pct: val,
-											}))
-											.sort((a, b) => b.pct - a.pct)
-											.slice(0, 10);
+									<TabsContent value="columns">
+										{explorerDs.dataset_metadata?.dtypes ? (
+											<div className="rounded-lg border overflow-auto">
+												<table className="min-w-full text-sm">
+													<thead className="bg-muted/60">
+														<tr>
+															<th className="px-4 py-2 text-left font-semibold border-b">
+																Column
+															</th>
+															<th className="px-4 py-2 text-left font-semibold border-b">
+																Type
+															</th>
+															<th className="px-4 py-2 text-left font-semibold border-b">
+																Missing
+															</th>
+														</tr>
+													</thead>
+													<tbody>
+														{Object.entries(
+															explorerDs.dataset_metadata.dtypes,
+														).map(([col, dtype]) => {
+															const pct =
+																explorerDs.dataset_metadata
+																	.missing_percentage?.[col] ?? 0;
+															return (
+																<tr
+																	key={col}
+																	className="border-b last:border-0 hover:bg-muted/30"
+																>
+																	<td className="px-4 py-2 font-medium font-mono text-xs">
+																		{col}
+																	</td>
+																	<td className="px-4 py-2">
+																		<Badge
+																			variant="outline"
+																			className="text-xs"
+																		>
+																			{dtype}
+																		</Badge>
+																	</td>
+																	<td className="px-4 py-2">
+																		<div className="flex items-center gap-2">
+																			<Progress
+																				value={pct}
+																				className="h-1.5 w-16"
+																			/>
+																			<span className="text-xs text-muted-foreground w-10">
+																				{pct.toFixed(1)}%
+																			</span>
+																		</div>
+																	</td>
+																</tr>
+															);
+														})}
+													</tbody>
+												</table>
+											</div>
+										) : (
+											<p className="text-sm text-muted-foreground">
+												No column metadata available.
+											</p>
+										)}
+									</TabsContent>
 
-										// Numeric ranges (min/max/mean) for up to 8 columns
-										const rangeData = numericCols.slice(0, 8).map((col) => ({
-											col: col.length > 8 ? `${col.slice(0, 8)}…` : col,
-											mean: parseFloat((stats[col]?.mean ?? 0).toFixed(2)),
-											min: parseFloat((stats[col]?.min ?? 0).toFixed(2)),
-											max: parseFloat((stats[col]?.max ?? 0).toFixed(2)),
-										}));
+									<TabsContent value="stats" className="space-y-4">
+										{(() => {
+											const stats = explorerDs.dataset_metadata?.statistics;
+											const dtypes = explorerDs.dataset_metadata?.dtypes ?? {};
+											const numericCols = Object.entries(dtypes)
+												.filter(
+													([, t]) => t.includes("int") || t.includes("float"),
+												)
+												.map(([c]) => c);
 
-										const CHART_COLORS = [
-											"#5B8AF0",
-											"#4DC0A0",
-											"#F5C842",
-											"#A78BFA",
-											"#E05C5C",
-										];
-
-										const TOOLTIP_STYLE = {
-											backgroundColor: "#1e2130",
-											border: "1px solid rgba(255,255,255,0.1)",
-											borderRadius: 8,
-											fontSize: 11,
-										};
-
-										return (
-											<>
-												{/* Summary stat cards */}
-												<div className="grid grid-cols-3 gap-2">
-													{[
-														{
-															label: "Numeric cols",
-															value: numericCols.length,
-														},
-														{
-															label: "Total rows",
-															value: explorerDs.rows.toLocaleString(),
-														},
-														{ label: "Total cols", value: explorerDs.columns },
-													].map(({ label, value }) => (
-														<div
-															key={label}
-															className="rounded-lg bg-muted/40 border p-2 text-center"
-														>
-															<p className="text-xs text-muted-foreground">
-																{label}
-															</p>
-															<p className="text-base font-bold">{value}</p>
-														</div>
-													))}
-												</div>
-
-												{/* Mean values bar chart */}
-												<div>
-													<p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-2">
-														Column Mean Values
+											if (!stats || numericCols.length === 0) {
+												return (
+													<p className="text-sm text-muted-foreground text-center py-8">
+														No numeric columns found. Refresh metadata to
+														compute statistics.
 													</p>
-													<ResponsiveContainer width="100%" height={160}>
-														<BarChart
-															data={rangeData}
-															margin={{
-																top: 2,
-																right: 4,
-																bottom: 0,
-																left: -20,
-															}}
-														>
-															<CartesianGrid
-																strokeDasharray="3 3"
-																stroke="rgba(255,255,255,0.06)"
-																vertical={false}
-															/>
-															<XAxis
-																dataKey="col"
-																tick={{ fontSize: 10, fill: "#888" }}
-																tickLine={false}
-																axisLine={false}
-															/>
-															<YAxis
-																tick={{ fontSize: 10, fill: "#888" }}
-																tickLine={false}
-																axisLine={false}
-															/>
-															<Tooltip
-																contentStyle={TOOLTIP_STYLE}
-																labelStyle={{ color: "#888" }}
-															/>
-															<Bar
-																dataKey="mean"
-																name="Mean"
-																radius={[4, 4, 0, 0]}
-															>
-																{rangeData.map((_, i) => (
-																	<Cell
-																		key={i}
-																		fill={CHART_COLORS[i % CHART_COLORS.length]}
-																	/>
-																))}
-															</Bar>
-														</BarChart>
-													</ResponsiveContainer>
-												</div>
+												);
+											}
 
-												{/* Missing values chart (if any) */}
-												{missingData.length > 0 && (
+											// Missing values bar chart data
+											const missingData = Object.entries(
+												explorerDs.dataset_metadata.missing_percentage ?? {},
+											)
+												.filter(([, v]) => v > 0)
+												.map(([col, val]) => ({
+													col: col.length > 10 ? `${col.slice(0, 10)}…` : col,
+													pct: val,
+												}))
+												.sort((a, b) => b.pct - a.pct)
+												.slice(0, 10);
+
+											// Numeric ranges (min/max/mean) for up to 8 columns
+											const rangeData = numericCols.slice(0, 8).map((col) => ({
+												col: col.length > 8 ? `${col.slice(0, 8)}…` : col,
+												mean: parseFloat((stats[col]?.mean ?? 0).toFixed(2)),
+												min: parseFloat((stats[col]?.min ?? 0).toFixed(2)),
+												max: parseFloat((stats[col]?.max ?? 0).toFixed(2)),
+											}));
+
+											const CHART_COLORS = [
+												"#5B8AF0",
+												"#4DC0A0",
+												"#F5C842",
+												"#A78BFA",
+												"#E05C5C",
+											];
+
+											const TOOLTIP_STYLE = {
+												backgroundColor: "#1e2130",
+												border: "1px solid rgba(255,255,255,0.1)",
+												borderRadius: 8,
+												fontSize: 11,
+											};
+
+											return (
+												<>
+													{/* Summary stat cards */}
+													<div className="grid grid-cols-3 gap-2">
+														{[
+															{
+																label: "Numeric cols",
+																value: numericCols.length,
+															},
+															{
+																label: "Total rows",
+																value: explorerDs.rows.toLocaleString(),
+															},
+															{
+																label: "Total cols",
+																value: explorerDs.columns,
+															},
+														].map(({ label, value }) => (
+															<div
+																key={label}
+																className="rounded-lg bg-muted/40 border p-2 text-center"
+															>
+																<p className="text-xs text-muted-foreground">
+																	{label}
+																</p>
+																<p className="text-base font-bold">{value}</p>
+															</div>
+														))}
+													</div>
+
+													{/* Mean values bar chart */}
 													<div>
 														<p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-2">
-															Missing Values (%)
+															Column Mean Values
 														</p>
-														<ResponsiveContainer width="100%" height={130}>
+														<ResponsiveContainer width="100%" height={160}>
 															<BarChart
-																data={missingData}
+																data={rangeData}
 																margin={{
 																	top: 2,
 																	right: 4,
@@ -1233,323 +1228,333 @@ export function DatasetsPage() {
 																	axisLine={false}
 																/>
 																<YAxis
-																	domain={[0, 100]}
 																	tick={{ fontSize: 10, fill: "#888" }}
 																	tickLine={false}
 																	axisLine={false}
-																	unit="%"
 																/>
-																<Tooltip contentStyle={TOOLTIP_STYLE} />
+																<Tooltip
+																	contentStyle={TOOLTIP_STYLE}
+																	labelStyle={{ color: "#888" }}
+																/>
 																<Bar
-																	dataKey="pct"
-																	name="Missing %"
-																	fill="#F5C842"
+																	dataKey="mean"
+																	name="Mean"
 																	radius={[4, 4, 0, 0]}
-																/>
+																>
+																	{rangeData.map((_, i) => (
+																		<Cell
+																			key={i}
+																			fill={
+																				CHART_COLORS[i % CHART_COLORS.length]
+																			}
+																		/>
+																	))}
+																</Bar>
 															</BarChart>
 														</ResponsiveContainer>
 													</div>
-												)}
 
-												{/* Numeric statistics table */}
-												<div>
-													<p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-2">
-														Descriptive Statistics
-													</p>
-													<div className="rounded-lg border overflow-auto">
-														<table className="min-w-full text-xs">
-															<thead className="bg-muted/60">
-																<tr>
-																	{["Column", "Min", "Max", "Mean", "Std"].map(
-																		(h) => (
+													{/* Missing values chart (if any) */}
+													{missingData.length > 0 && (
+														<div>
+															<p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-2">
+																Missing Values (%)
+															</p>
+															<ResponsiveContainer width="100%" height={130}>
+																<BarChart
+																	data={missingData}
+																	margin={{
+																		top: 2,
+																		right: 4,
+																		bottom: 0,
+																		left: -20,
+																	}}
+																>
+																	<CartesianGrid
+																		strokeDasharray="3 3"
+																		stroke="rgba(255,255,255,0.06)"
+																		vertical={false}
+																	/>
+																	<XAxis
+																		dataKey="col"
+																		tick={{ fontSize: 10, fill: "#888" }}
+																		tickLine={false}
+																		axisLine={false}
+																	/>
+																	<YAxis
+																		domain={[0, 100]}
+																		tick={{ fontSize: 10, fill: "#888" }}
+																		tickLine={false}
+																		axisLine={false}
+																		unit="%"
+																	/>
+																	<Tooltip contentStyle={TOOLTIP_STYLE} />
+																	<Bar
+																		dataKey="pct"
+																		name="Missing %"
+																		fill="#F5C842"
+																		radius={[4, 4, 0, 0]}
+																	/>
+																</BarChart>
+															</ResponsiveContainer>
+														</div>
+													)}
+
+													{/* Numeric statistics table */}
+													<div>
+														<p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-2">
+															Descriptive Statistics
+														</p>
+														<div className="rounded-lg border overflow-auto">
+															<table className="min-w-full text-xs">
+																<thead className="bg-muted/60">
+																	<tr>
+																		{[
+																			"Column",
+																			"Count",
+																			"Mean",
+																			"Std",
+																			"Min",
+																			"25%",
+																			"50%",
+																			"75%",
+																			"Max",
+																		].map((h) => (
 																			<th
 																				key={h}
 																				className="px-3 py-1.5 text-left font-semibold border-b whitespace-nowrap"
 																			>
 																				{h}
 																			</th>
-																		),
-																	)}
-																</tr>
-															</thead>
-															<tbody>
-																{numericCols.map((col) => (
-																	<tr
-																		key={col}
-																		className="border-b last:border-0 hover:bg-muted/20"
-																	>
-																		<td className="px-3 py-1.5 font-medium font-mono">
-																			{col}
-																		</td>
-																		<td className="px-3 py-1.5 text-muted-foreground">
-																			{(stats[col]?.min ?? 0).toFixed(2)}
-																		</td>
-																		<td className="px-3 py-1.5 text-muted-foreground">
-																			{(stats[col]?.max ?? 0).toFixed(2)}
-																		</td>
-																		<td className="px-3 py-1.5 text-muted-foreground">
-																			{(stats[col]?.mean ?? 0).toFixed(2)}
-																		</td>
-																		<td className="px-3 py-1.5 text-muted-foreground">
-																			{(stats[col]?.std ?? 0).toFixed(2)}
-																		</td>
+																		))}
 																	</tr>
-																))}
-															</tbody>
-														</table>
-													</div>
-												</div>
-											</>
-										);
-									})()}
-								</TabsContent>
-								<TabsContent value="wrangle">
-									<div className="rounded-xl border bg-card text-card-foreground shadow-sm p-5 space-y-4">
-										<div>
-											<h3 className="text-lg font-semibold flex items-center gap-2">
-												<Wand2 className="w-5 h-5" /> Data Pipeline
-											</h3>
-											<p className="text-sm text-muted-foreground">
-												Configurations set here execute on the backend, generating a cleanly formatted derivative version of your dataset.
-											</p>
-										</div>
-										<Tabs defaultValue="clean" className="mt-2 w-full">
-											<TabsList className="w-full">
-												<TabsTrigger value="clean" className="flex-1">
-													Clean
-												</TabsTrigger>
-												<TabsTrigger value="transform" className="flex-1">
-													Transform
-												</TabsTrigger>
-											</TabsList>
-
-											{/* ── Clean tab ── */}
-											<TabsContent value="clean" className="space-y-4 pt-4 pb-2">
-												<div className="space-y-1.5">
-													<Label>Strategy</Label>
-													<Select
-														value={cleanStrategy}
-														onValueChange={setCleanStrategy}
-													>
-														<SelectTrigger>
-															<SelectValue />
-														</SelectTrigger>
-														<SelectContent>
-															{CLEAN_STRATEGIES.map((s) => (
-																<SelectItem key={s.value} value={s.value}>
-																	{s.label}
-																</SelectItem>
-															))}
-														</SelectContent>
-													</Select>
-												</div>
-
-												{/* Column picker for clean */}
-												{(() => {
-													const dtypes = explorerDs?.dataset_metadata?.dtypes ?? {};
-													const allCols = Object.keys(dtypes);
-													if (allCols.length === 0) return null;
-													const toggleCol = (col: string) =>
-														setCleanCols((prev) =>
-															prev.includes(col)
-																? prev.filter((c) => c !== col)
-																: [...prev, col],
-														);
-													const filteredCols = cleanSearch ? allCols.filter(c => c.toLowerCase().includes(cleanSearch.toLowerCase())) : allCols;
-													return (
-														<div className="space-y-1.5">
-															<div className="flex items-center justify-between">
-																<Label className="text-sm">Columns</Label>
-																<div className="flex gap-2 text-xs">
-																	<button
-																		type="button"
-																		className="text-primary hover:underline"
-																		onClick={() => setCleanCols(allCols)}
-																	>
-																		All
-																	</button>
-																	<span className="text-muted-foreground">·</span>
-																	<button
-																		type="button"
-																		className="text-muted-foreground hover:underline"
-																		onClick={() => setCleanCols([])}
-																	>
-																		None
-																	</button>
-																</div>
-															</div>
-															<Input
-																placeholder="Search columns..."
-																value={cleanSearch}
-																onChange={(e) => setCleanSearch(e.target.value)}
-																className="h-8 text-xs"
-															/>
-															<p className="text-xs text-muted-foreground">
-																Leave all unselected to apply to every column.
-															</p>
-															<div className="rounded-lg border bg-muted/20 p-2 max-h-40 overflow-y-auto grid grid-cols-2 gap-1">
-																{filteredCols.map((col) => (
-																	<label
-																		key={col}
-																		className="flex items-center gap-2 px-2 py-1.5 rounded-md hover:bg-muted/50 cursor-pointer text-xs"
-																	>
-																		<input
-																			type="checkbox"
-																			className="accent-primary w-3.5 h-3.5 shrink-0"
-																			checked={cleanCols.includes(col)}
-																			onChange={() => toggleCol(col)}
-																		/>
-																		<span className="truncate font-mono" title={col}>
-																			{col}
-																		</span>
-																		<span className="ml-auto text-muted-foreground shrink-0">
-																			{dtypes[col]}
-																		</span>
-																	</label>
-																))}
-															</div>
-															{cleanCols.length > 0 && (
-																<p className="text-xs text-primary">
-																	{cleanCols.length} column
-																	{cleanCols.length > 1 ? "s" : ""} selected
-																</p>
-															)}
+																</thead>
+																<tbody>
+																	{numericCols.map((col) => (
+																		<tr
+																			key={col}
+																			className="border-b last:border-0 hover:bg-muted/20"
+																		>
+																			<td className="px-3 py-1.5 font-medium font-mono">
+																				{col}
+																			</td>
+																			<td className="px-3 py-1.5 text-muted-foreground">
+																				{(stats[col]?.count ?? 0).toFixed(0)}
+																			</td>
+																			<td className="px-3 py-1.5 text-muted-foreground">
+																				{(stats[col]?.mean ?? 0).toFixed(2)}
+																			</td>
+																			<td className="px-3 py-1.5 text-muted-foreground">
+																				{(stats[col]?.std ?? 0).toFixed(2)}
+																			</td>
+																			<td className="px-3 py-1.5 text-muted-foreground">
+																				{(stats[col]?.min ?? 0).toFixed(2)}
+																			</td>
+																			<td className="px-3 py-1.5 text-muted-foreground">
+																				{(stats[col]?.["25%"] ?? 0).toFixed(2)}
+																			</td>
+																			<td className="px-3 py-1.5 text-muted-foreground">
+																				{(stats[col]?.["50%"] ?? 0).toFixed(2)}
+																			</td>
+																			<td className="px-3 py-1.5 text-muted-foreground">
+																				{(stats[col]?.["75%"] ?? 0).toFixed(2)}
+																			</td>
+																			<td className="px-3 py-1.5 text-muted-foreground">
+																				{(stats[col]?.max ?? 0).toFixed(2)}
+																			</td>
+																		</tr>
+																	))}
+																</tbody>
+															</table>
 														</div>
-													);
-												})()}
+													</div>
 
-												<div className="flex justify-end pt-2 pb-1">
-													<Button onClick={handleClean} disabled={isWrangling}>
-														{isWrangling ? (
-															<>
-																<Loader2 className="w-4 h-4 mr-2 animate-spin" />{" "}
-																Executing Pipeline...
-															</>
-														) : (
-															"Apply Clean"
-														)}
-													</Button>
-												</div>
-											</TabsContent>
+													{/* Correlation Matrix */}
+													{(() => {
+														const correlationDict =
+															explorerDs.dataset_metadata?.correlation;
+														const corrCols = correlationDict
+															? Object.keys(correlationDict)
+															: [];
+														if (corrCols.length < 2) return null;
 
-											{/* ── Transform tab ── */}
-											<TabsContent value="transform" className="space-y-4 pt-4 pb-2">
-												<div className="space-y-1.5">
-													<Label>Strategy</Label>
-													<Select
-														value={transformStrategy}
-														onValueChange={(v) => {
-															setTransformStrategy(v);
-															const dtypes = explorerDs?.dataset_metadata?.dtypes ?? {};
-															if (v === "label_encoder") {
-																const catCols = Object.entries(dtypes)
-																	.filter(
-																		([, t]) =>
-																			!(t as string).includes("int") &&
-																			!(t as string).includes("float"),
-																	)
-																	.map(([c]) => c);
-																setTransformCols(catCols);
-															} else {
-																const numCols = Object.entries(dtypes)
-																	.filter(
-																		([, t]) =>
-																			(t as string).includes("int") ||
-																			(t as string).includes("float"),
-																	)
-																	.map(([c]) => c);
-																setTransformCols(numCols);
-															}
-														}}
-													>
-														<SelectTrigger>
-															<SelectValue />
-														</SelectTrigger>
-														<SelectContent>
-															{TRANSFORM_STRATEGIES.map((s) => (
-																<SelectItem key={s.value} value={s.value}>
-																	{s.label}
-																</SelectItem>
-															))}
-														</SelectContent>
-													</Select>
-													<p className="text-xs text-muted-foreground">
-														{transformStrategy === "label_encoder"
-															? "Encodes text/category columns as integers. Select the columns to encode."
-															: "Scales numeric columns. Select which columns to scale, or leave all selected."}
-													</p>
-												</div>
-
-												{/* Column picker for transform */}
-												{(() => {
-													const dtypes = explorerDs?.dataset_metadata?.dtypes ?? {};
-													const isLabelEncode = transformStrategy === "label_encoder" || transformStrategy === "one_hot_encoder";
-
-													const eligibleCols = isLabelEncode
-														? Object.keys(dtypes)
-														: Object.entries(dtypes)
-																.filter(
-																	([, t]) =>
-																		(t as string).includes("int") ||
-																		(t as string).includes("float"),
-																)
-																.map(([c]) => c);
-
-													if (eligibleCols.length === 0)
 														return (
-															<p className="text-xs text-muted-foreground">
-																No eligible columns found.
-															</p>
-														);
-
-													const toggleCol = (col: string) =>
-														setTransformCols((prev) =>
-															prev.includes(col)
-																? prev.filter((c) => c !== col)
-																: [...prev, col],
-														);
-
-													const filteredCols = transformSearch ? eligibleCols.filter(c => c.toLowerCase().includes(transformSearch.toLowerCase())) : eligibleCols;
-
-													return (
-														<div className="space-y-1.5">
-															<div className="flex items-center justify-between">
-																<Label className="text-sm">
-																	Columns
-																	{isLabelEncode && (
-																		<span className="text-destructive ml-1">*</span>
-																	)}
-																</Label>
-																<div className="flex gap-2 text-xs">
-																	<button
-																		type="button"
-																		className="text-primary hover:underline"
-																		onClick={() => setTransformCols(eligibleCols)}
+															<div className="pt-2">
+																<p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-2">
+																	Correlation Matrix
+																</p>
+																<div className="overflow-auto border rounded-xl bg-card p-4">
+																	<div
+																		className="grid gap-[2px] min-w-max items-center"
+																		style={{
+																			gridTemplateColumns: `max-content repeat(${corrCols.length}, 36px)`,
+																		}}
 																	>
-																		All
-																	</button>
-																	<span className="text-muted-foreground">·</span>
-																	<button
-																		type="button"
-																		className="text-muted-foreground hover:underline"
-																		onClick={() => setTransformCols([])}
-																	>
-																		None
-																	</button>
+																		{/* Header row */}
+																		<div className="h-6"></div>
+																		{corrCols.map((c) => (
+																			<div
+																				key={c}
+																				className="text-[10px] font-mono text-center truncate text-muted-foreground pb-1"
+																				title={c}
+																			>
+																				{c.slice(0, 4)}
+																			</div>
+																		))}
+
+																		{/* Data rows */}
+																		{corrCols.map((row) => (
+																			<div
+																				key={row}
+																				style={{ display: "contents" }}
+																			>
+																				<div
+																					className="text-[10px] font-mono pr-3 text-right text-muted-foreground truncate max-w-[100px]"
+																					title={row}
+																				>
+																					{row}
+																				</div>
+																				{corrCols.map((col) => {
+																					const val =
+																						correlationDict[row][col] ?? 0;
+																					const isPositive = val >= 0;
+																					const opacity = Math.abs(val);
+																					// Green for pos, Red for neg
+																					const bg = isPositive
+																						? `rgba(77, 192, 160, ${opacity * 0.9 + 0.1})`
+																						: `rgba(224, 92, 92, ${opacity * 0.9 + 0.1})`;
+																					const isSelf = row === col;
+																					const showText =
+																						opacity > 0.4 && !isSelf;
+
+																					return (
+																						<div
+																							key={col}
+																							className={`h-9 flex items-center justify-center text-[10px] font-medium ${isSelf ? "bg-muted/80 text-muted-foreground/60" : showText ? "text-white" : "text-transparent"}`}
+																							style={{
+																								backgroundColor: isSelf
+																									? undefined
+																									: bg,
+																							}}
+																							title={`${row} ↔ ${col}: ${val.toFixed(3)}`}
+																						>
+																							{isSelf ? "—" : val.toFixed(1)}
+																						</div>
+																					);
+																				})}
+																			</div>
+																		))}
+																	</div>
 																</div>
 															</div>
-															<Input
-																placeholder="Search columns..."
-																value={transformSearch}
-																onChange={(e) => setTransformSearch(e.target.value)}
-																className="h-8 text-xs"
-															/>
-															<div className="rounded-lg border bg-muted/20 p-2 max-h-44 overflow-y-auto grid grid-cols-2 gap-1">
-																{filteredCols.map((col) => {
-																	const dtype = dtypes[col] as string;
-																	const isCat =
-																		!dtype.includes("int") && !dtype.includes("float");
-																	return (
+														);
+													})()}
+												</>
+											);
+										})()}
+									</TabsContent>
+									<TabsContent value="wrangle">
+										<div className="rounded-xl border bg-card text-card-foreground shadow-sm p-5 space-y-4">
+											<div>
+												<h3 className="text-lg font-semibold flex items-center gap-2">
+													<Wand2 className="w-5 h-5" /> Data Pipeline
+												</h3>
+												<p className="text-sm text-muted-foreground">
+													Configurations set here execute on the backend,
+													generating a cleanly formatted derivative version of
+													your dataset.
+												</p>
+											</div>
+											<Tabs defaultValue="clean" className="mt-2 w-full">
+												<TabsList className="w-full">
+													<TabsTrigger value="clean" className="flex-1">
+														Clean
+													</TabsTrigger>
+													<TabsTrigger value="transform" className="flex-1">
+														Transform
+													</TabsTrigger>
+												</TabsList>
+
+												{/* ── Clean tab ── */}
+												<TabsContent
+													value="clean"
+													className="space-y-4 pt-4 pb-2"
+												>
+													<div className="space-y-1.5">
+														<Label>Strategy</Label>
+														<Select
+															value={cleanStrategy}
+															onValueChange={setCleanStrategy}
+														>
+															<SelectTrigger>
+																<SelectValue />
+															</SelectTrigger>
+															<SelectContent>
+																{CLEAN_STRATEGIES.map((s) => (
+																	<SelectItem key={s.value} value={s.value}>
+																		{s.label}
+																	</SelectItem>
+																))}
+															</SelectContent>
+														</Select>
+													</div>
+
+													{/* Column picker for clean */}
+													{(() => {
+														const dtypes =
+															explorerDs?.dataset_metadata?.dtypes ?? {};
+														const allCols = Object.keys(dtypes);
+														if (allCols.length === 0) return null;
+														const toggleCol = (col: string) =>
+															setCleanCols((prev) =>
+																prev.includes(col)
+																	? prev.filter((c) => c !== col)
+																	: [...prev, col],
+															);
+														const filteredCols = cleanSearch
+															? allCols.filter((c) =>
+																	c
+																		.toLowerCase()
+																		.includes(cleanSearch.toLowerCase()),
+																)
+															: allCols;
+														return (
+															<div className="space-y-1.5">
+																<div className="flex items-center justify-between">
+																	<Label className="text-sm">Columns</Label>
+																	<div className="flex gap-2 text-xs">
+																		<button
+																			type="button"
+																			className="text-primary hover:underline"
+																			onClick={() => setCleanCols(allCols)}
+																		>
+																			All
+																		</button>
+																		<span className="text-muted-foreground">
+																			·
+																		</span>
+																		<button
+																			type="button"
+																			className="text-muted-foreground hover:underline"
+																			onClick={() => setCleanCols([])}
+																		>
+																			None
+																		</button>
+																	</div>
+																</div>
+																<Input
+																	placeholder="Search columns..."
+																	value={cleanSearch}
+																	onChange={(e) =>
+																		setCleanSearch(e.target.value)
+																	}
+																	className="h-8 text-xs"
+																/>
+																<p className="text-xs text-muted-foreground">
+																	Leave all unselected to apply to every column.
+																</p>
+																<div className="rounded-lg border bg-muted/20 p-2 max-h-40 overflow-y-auto grid grid-cols-2 gap-1">
+																	{filteredCols.map((col) => (
 																		<label
 																			key={col}
 																			className="flex items-center gap-2 px-2 py-1.5 rounded-md hover:bg-muted/50 cursor-pointer text-xs"
@@ -1557,53 +1562,249 @@ export function DatasetsPage() {
 																			<input
 																				type="checkbox"
 																				className="accent-primary w-3.5 h-3.5 shrink-0"
-																				checked={transformCols.includes(col)}
+																				checked={cleanCols.includes(col)}
 																				onChange={() => toggleCol(col)}
 																			/>
-																			<span className="truncate font-mono" title={col}>
+																			<span
+																				className="truncate font-mono"
+																				title={col}
+																			>
 																				{col}
 																			</span>
-																			<Badge
-																				variant="outline"
-																				className={`ml-auto text-[10px] px-1 py-0 h-4 shrink-0 ${isCat ? "border-amber-500/40 text-amber-400" : "border-blue-500/40 text-blue-400"}`}
-																			>
-																				{isCat ? "cat" : "num"}
-																			</Badge>
+																			<span className="ml-auto text-muted-foreground shrink-0">
+																				{dtypes[col]}
+																			</span>
 																		</label>
-																	);
-																})}
+																	))}
+																</div>
+																{cleanCols.length > 0 && (
+																	<p className="text-xs text-primary">
+																		{cleanCols.length} column
+																		{cleanCols.length > 1 ? "s" : ""} selected
+																	</p>
+																)}
 															</div>
-															{transformCols.length > 0 ? (
-																<p className="text-xs text-primary">
-																	{transformCols.length} column
-																	{transformCols.length > 1 ? "s" : ""} selected
-																</p>
-															) : isLabelEncode ? (
-																<p className="text-xs text-destructive">
-																	At least one column must be selected
-																</p>
-															) : null}
-														</div>
-													);
-												})()}
+														);
+													})()}
 
-												<div className="flex justify-end pt-2 pb-1">
-													<Button onClick={handleTransform} disabled={isWrangling}>
-														{isWrangling ? (
-															<>
-																<Loader2 className="w-4 h-4 mr-2 animate-spin" />{" "}
-																Executing Pipeline...
-															</>
-														) : (
-															"Apply Transform"
-														)}
-													</Button>
-												</div>
-											</TabsContent>
-										</Tabs>
-									</div>
-								</TabsContent>
-							</Tabs>
+													<div className="flex justify-end pt-2 pb-1">
+														<Button
+															onClick={handleClean}
+															disabled={isWrangling}
+														>
+															{isWrangling ? (
+																<>
+																	<Loader2 className="w-4 h-4 mr-2 animate-spin" />{" "}
+																	Executing Pipeline...
+																</>
+															) : (
+																"Apply Clean"
+															)}
+														</Button>
+													</div>
+												</TabsContent>
+
+												{/* ── Transform tab ── */}
+												<TabsContent
+													value="transform"
+													className="space-y-4 pt-4 pb-2"
+												>
+													<div className="space-y-1.5">
+														<Label>Strategy</Label>
+														<Select
+															value={transformStrategy}
+															onValueChange={(v) => {
+																setTransformStrategy(v);
+																const dtypes =
+																	explorerDs?.dataset_metadata?.dtypes ?? {};
+																if (v === "label_encoder") {
+																	const catCols = Object.entries(dtypes)
+																		.filter(
+																			([, t]) =>
+																				!(t as string).includes("int") &&
+																				!(t as string).includes("float"),
+																		)
+																		.map(([c]) => c);
+																	setTransformCols(catCols);
+																} else {
+																	const numCols = Object.entries(dtypes)
+																		.filter(
+																			([, t]) =>
+																				(t as string).includes("int") ||
+																				(t as string).includes("float"),
+																		)
+																		.map(([c]) => c);
+																	setTransformCols(numCols);
+																}
+															}}
+														>
+															<SelectTrigger>
+																<SelectValue />
+															</SelectTrigger>
+															<SelectContent>
+																{TRANSFORM_STRATEGIES.map((s) => (
+																	<SelectItem key={s.value} value={s.value}>
+																		{s.label}
+																	</SelectItem>
+																))}
+															</SelectContent>
+														</Select>
+														<p className="text-xs text-muted-foreground">
+															{transformStrategy === "label_encoder"
+																? "Encodes text/category columns as integers. Select the columns to encode."
+																: "Scales numeric columns. Select which columns to scale, or leave all selected."}
+														</p>
+													</div>
+
+													{/* Column picker for transform */}
+													{(() => {
+														const dtypes =
+															explorerDs?.dataset_metadata?.dtypes ?? {};
+														const isLabelEncode =
+															transformStrategy === "label_encoder" ||
+															transformStrategy === "one_hot_encoder";
+
+														const eligibleCols = isLabelEncode
+															? Object.keys(dtypes)
+															: Object.entries(dtypes)
+																	.filter(
+																		([, t]) =>
+																			(t as string).includes("int") ||
+																			(t as string).includes("float"),
+																	)
+																	.map(([c]) => c);
+
+														if (eligibleCols.length === 0)
+															return (
+																<p className="text-xs text-muted-foreground">
+																	No eligible columns found.
+																</p>
+															);
+
+														const toggleCol = (col: string) =>
+															setTransformCols((prev) =>
+																prev.includes(col)
+																	? prev.filter((c) => c !== col)
+																	: [...prev, col],
+															);
+
+														const filteredCols = transformSearch
+															? eligibleCols.filter((c) =>
+																	c
+																		.toLowerCase()
+																		.includes(transformSearch.toLowerCase()),
+																)
+															: eligibleCols;
+
+														return (
+															<div className="space-y-1.5">
+																<div className="flex items-center justify-between">
+																	<Label className="text-sm">
+																		Columns
+																		{isLabelEncode && (
+																			<span className="text-destructive ml-1">
+																				*
+																			</span>
+																		)}
+																	</Label>
+																	<div className="flex gap-2 text-xs">
+																		<button
+																			type="button"
+																			className="text-primary hover:underline"
+																			onClick={() =>
+																				setTransformCols(eligibleCols)
+																			}
+																		>
+																			All
+																		</button>
+																		<span className="text-muted-foreground">
+																			·
+																		</span>
+																		<button
+																			type="button"
+																			className="text-muted-foreground hover:underline"
+																			onClick={() => setTransformCols([])}
+																		>
+																			None
+																		</button>
+																	</div>
+																</div>
+																<Input
+																	placeholder="Search columns..."
+																	value={transformSearch}
+																	onChange={(e) =>
+																		setTransformSearch(e.target.value)
+																	}
+																	className="h-8 text-xs"
+																/>
+																<div className="rounded-lg border bg-muted/20 p-2 max-h-44 overflow-y-auto grid grid-cols-2 gap-1">
+																	{filteredCols.map((col) => {
+																		const dtype = dtypes[col] as string;
+																		const isCat =
+																			!dtype.includes("int") &&
+																			!dtype.includes("float");
+																		return (
+																			<label
+																				key={col}
+																				className="flex items-center gap-2 px-2 py-1.5 rounded-md hover:bg-muted/50 cursor-pointer text-xs"
+																			>
+																				<input
+																					type="checkbox"
+																					className="accent-primary w-3.5 h-3.5 shrink-0"
+																					checked={transformCols.includes(col)}
+																					onChange={() => toggleCol(col)}
+																				/>
+																				<span
+																					className="truncate font-mono"
+																					title={col}
+																				>
+																					{col}
+																				</span>
+																				<Badge
+																					variant="outline"
+																					className={`ml-auto text-[10px] px-1 py-0 h-4 shrink-0 ${isCat ? "border-amber-500/40 text-amber-400" : "border-blue-500/40 text-blue-400"}`}
+																				>
+																					{isCat ? "cat" : "num"}
+																				</Badge>
+																			</label>
+																		);
+																	})}
+																</div>
+																{transformCols.length > 0 ? (
+																	<p className="text-xs text-primary">
+																		{transformCols.length} column
+																		{transformCols.length > 1 ? "s" : ""}{" "}
+																		selected
+																	</p>
+																) : isLabelEncode ? (
+																	<p className="text-xs text-destructive">
+																		At least one column must be selected
+																	</p>
+																) : null}
+															</div>
+														);
+													})()}
+
+													<div className="flex justify-end pt-2 pb-1">
+														<Button
+															onClick={handleTransform}
+															disabled={isWrangling}
+														>
+															{isWrangling ? (
+																<>
+																	<Loader2 className="w-4 h-4 mr-2 animate-spin" />{" "}
+																	Executing Pipeline...
+																</>
+															) : (
+																"Apply Transform"
+															)}
+														</Button>
+													</div>
+												</TabsContent>
+											</Tabs>
+										</div>
+									</TabsContent>
+								</Tabs>
 							</div>
 
 							<div className="mt-4 pt-4 border-t flex gap-2 shrink-0 bg-background">

--- a/client/src/pages/DatasetsPage.tsx
+++ b/client/src/pages/DatasetsPage.tsx
@@ -367,7 +367,7 @@ export function DatasetsPage() {
 						setTotalRows(res.data.total_rows);
 						setTotalPages(res.data.total_pages);
 					}
-				} catch (err) {
+				} catch (_err) {
 					if (isMounted) toast.error("Failed to load data for preview");
 				} finally {
 					if (isMounted) setLoading(false);

--- a/client/src/pages/DatasetsPage.tsx
+++ b/client/src/pages/DatasetsPage.tsx
@@ -138,8 +138,10 @@ export function DatasetsPage() {
 	const [isWrangling, setIsWrangling] = useState(false);
 	const [cleanStrategy, setCleanStrategy] = useState("drop_nulls");
 	const [cleanCols, setCleanCols] = useState<string[]>([]);
+	const [cleanSearch, setCleanSearch] = useState("");
 	const [transformStrategy, setTransformStrategy] = useState("standard_scaler");
 	const [transformCols, setTransformCols] = useState<string[]>([]);
+	const [transformSearch, setTransformSearch] = useState("");
 
 	// Edit/rename dialog state
 	const [editDs, setEditDs] = useState<Dataset | null>(null);
@@ -343,51 +345,92 @@ export function DatasetsPage() {
 
 	// ── preview table ──────────────────────────────────────────────────
 	const PreviewTable = ({ ds }: { ds: Dataset }) => {
-		const preview = ds.dataset_metadata?.preview ?? [];
+		const [page, setPage] = useState(1);
+		const [data, setData] = useState<any[]>([]);
+		const [totalRows, setTotalRows] = useState(0);
+		const [totalPages, setTotalPages] = useState(0);
+		const [loading, setLoading] = useState(false);
+		const limit = 50;
+
+		useEffect(() => {
+			let isMounted = true;
+			const fetchData = async () => {
+				setLoading(true);
+				try {
+					const res = await api.get(`/dataset/${ds.id}/data?page=${page}&limit=${limit}`);
+					if (isMounted) {
+						setData(res.data.data);
+						setTotalRows(res.data.total_rows);
+						setTotalPages(res.data.total_pages);
+					}
+				} catch (err) {
+					if (isMounted) toast.error("Failed to load data for preview");
+				} finally {
+					if (isMounted) setLoading(false);
+				}
+			};
+			fetchData();
+			return () => { isMounted = false; };
+		}, [ds.id, page]);
+
 		const dtypes = ds.dataset_metadata?.dtypes ?? {};
 		const missing = ds.dataset_metadata?.missing_percentage ?? {};
 		const cols = Object.keys(dtypes);
-		if (preview.length === 0)
+
+		if (loading && data.length === 0) {
+			return <div className="flex justify-center p-8"><Loader2 className="w-6 h-6 animate-spin text-muted-foreground" /></div>;
+		}
+
+		if (!loading && data.length === 0)
 			return (
 				<p className="text-sm text-muted-foreground py-4 text-center">
 					No preview data available.
 				</p>
 			);
 		return (
-			<div className="overflow-auto rounded-lg border">
-				<table className="min-w-full text-xs">
-					<thead className="bg-muted/60 sticky top-0">
-						<tr>
-							{cols.map((c) => (
-								<th
-									key={c}
-									className="px-3 py-2 text-left font-semibold whitespace-nowrap border-b"
-								>
-									<div>{c}</div>
-									<div className="text-muted-foreground font-normal">
-										{dtypes[c]}
-									</div>
-								</th>
-							))}
-						</tr>
-					</thead>
-					<tbody>
-						{preview.map((row, i) => (
-							<tr
-								key={i}
-								className="border-b last:border-0 hover:bg-muted/30 transition-colors"
-							>
+			<div className="space-y-4">
+				<div className="overflow-auto rounded-lg border max-h-[500px]">
+					<table className="min-w-full text-xs">
+						<thead className="bg-muted/60 sticky top-0 z-10">
+							<tr>
 								{cols.map((c) => (
-									<td key={c} className="px-3 py-1.5 whitespace-nowrap">
-										{String(row[c] ?? "—")}
-									</td>
+									<th
+										key={c}
+										className="px-3 py-2 text-left font-semibold whitespace-nowrap border-b bg-muted/60 backdrop-blur-sm"
+									>
+										<div>{c}</div>
+										<div className="text-muted-foreground font-normal">
+											{dtypes[c]}
+										</div>
+									</th>
 								))}
 							</tr>
-						))}
-					</tbody>
-				</table>
+						</thead>
+						<tbody>
+							{data.map((row, i) => (
+								<tr
+									key={i}
+									className="border-b last:border-0 hover:bg-muted/30 transition-colors"
+								>
+									{cols.map((c) => (
+										<td key={c} className="px-3 py-1.5 whitespace-nowrap">
+											{String(row[c] ?? "—")}
+										</td>
+									))}
+								</tr>
+							))}
+						</tbody>
+					</table>
+				</div>
+                <div className="flex items-center justify-between text-sm">
+                    <span className="text-muted-foreground">Showing {(page-1)*limit + 1} to {Math.min(page*limit, totalRows)} of {totalRows} rows</span>
+                    <div className="flex gap-2">
+                        <Button variant="outline" size="sm" onClick={() => setPage(page - 1)} disabled={page <= 1 || loading}>Previous</Button>
+                        <Button variant="outline" size="sm" onClick={() => setPage(page + 1)} disabled={page >= totalPages || loading}>Next</Button>
+                    </div>
+                </div>
 				{cols.some((c) => (missing[c] ?? 0) > 0) && (
-					<div className="p-3 border-t bg-muted/20 space-y-1">
+					<div className="p-3 border rounded-lg bg-muted/20 space-y-1">
 						<p className="text-xs font-medium text-muted-foreground mb-2">
 							Missing Values
 						</p>
@@ -852,40 +895,46 @@ export function DatasetsPage() {
 									No version history found.
 								</p>
 							) : (
-								<div className="space-y-3">
+								<div className="relative border-l-2 border-muted/60 ml-4 space-y-6 py-4">
 									{[...versions]
 										.sort((a, b) => a.version.localeCompare(b.version))
 										.map((v) => (
 											<div
 												key={v.id}
-												className="rounded-lg border p-3 space-y-1.5 hover:bg-muted/30 transition-colors"
+												className="relative pl-6"
 											>
-												<div className="flex items-center justify-between">
-													<div className="flex items-center gap-2">
-														<Badge
-															variant="secondary"
-															className="font-mono text-xs"
-														>
-															v{v.version}
-														</Badge>
-														{!v.parent_id && (
+												{/* Connecting dot */}
+												<div className="absolute w-3.5 h-3.5 bg-primary/80 rounded-full -left-[8px] top-4 ring-4 ring-background" />
+
+												<div className="rounded-xl border bg-card text-card-foreground shadow-sm p-4 space-y-2 hover:border-primary/50 transition-colors hover:shadow-md cursor-default">
+													<div className="flex items-center justify-between">
+														<div className="flex items-center gap-2">
 															<Badge
-																variant="outline"
-																className="text-xs text-primary border-primary/40"
+																variant="secondary"
+																className="font-mono text-xs"
 															>
-																original
+																v{v.version}
 															</Badge>
-														)}
+															{!v.parent_id && (
+																<Badge
+																	variant="outline"
+																	className="text-xs text-primary border-primary/40"
+																>
+																	original
+																</Badge>
+															)}
+														</div>
+														<span className="text-[10px] uppercase font-bold tracking-wider text-muted-foreground">
+															{new Date(v.created_at).toLocaleDateString()}
+														</span>
 													</div>
-													<span className="text-xs text-muted-foreground">
-														{new Date(v.created_at).toLocaleDateString()}
-													</span>
+													<p className="text-sm font-semibold">{v.name}</p>
+													<div className="flex items-center gap-3 text-xs text-muted-foreground">
+														<span className="flex items-center gap-1"><BarChart3 className="w-3 h-3"/> {v.rows.toLocaleString()}</span>
+														<span className="flex items-center gap-1"><Filter className="w-3 h-3"/> {v.columns}</span>
+														<span className="flex items-center gap-1"><Sigma className="w-3 h-3"/> {v.file?.file_type?.toUpperCase() ?? "—"}</span>
+													</div>
 												</div>
-												<p className="text-sm font-medium">{v.name}</p>
-												<p className="text-xs text-muted-foreground">
-													{v.rows.toLocaleString()} rows · {v.columns} cols ·{" "}
-													{v.file?.file_type?.toUpperCase() ?? "—"}
-												</p>
 											</div>
 										))}
 								</div>
@@ -900,10 +949,11 @@ export function DatasetsPage() {
 				open={!!explorerDs}
 				onOpenChange={(o) => !o && setExplorerDs(null)}
 			>
-				<SheetContent className="w-full sm:max-w-3xl overflow-y-auto">
+				<SheetContent className="w-full sm:max-w-4xl flex flex-col h-full p-4 sm:p-6 overflow-hidden">
 					{explorerDs && (
 						<>
-							<SheetHeader className="mb-4">
+							<div className="flex-1 overflow-y-auto overflow-x-hidden pr-2 space-y-6">
+								<SheetHeader className="mb-2">
 								<SheetTitle className="flex items-center gap-2">
 									<Database className="w-5 h-5" />
 									{explorerDs.name}
@@ -1251,10 +1301,11 @@ export function DatasetsPage() {
 									})()}
 								</TabsContent>
 							</Tabs>
+							</div>
 
-							<div className="mt-4 flex gap-2">
+							<div className="mt-4 pt-4 border-t flex gap-2 shrink-0 bg-background">
 								<Button
-									className="gap-2 flex-1"
+									className="gap-2 flex-1 shadow-sm"
 									onClick={() => {
 										setWrangleDs(explorerDs);
 										setExplorerDs(null);
@@ -1264,7 +1315,7 @@ export function DatasetsPage() {
 								</Button>
 								<Button
 									variant="outline"
-									className="gap-2"
+									className="gap-2 shadow-sm"
 									onClick={() => {
 										openEdit(explorerDs);
 										setExplorerDs(null);
@@ -1274,7 +1325,7 @@ export function DatasetsPage() {
 								</Button>
 								<Button
 									variant="outline"
-									className="gap-2"
+									className="gap-2 shadow-sm"
 									onClick={() => handleRefresh(explorerDs.id, explorerDs.name)}
 								>
 									<RefreshCw className="w-4 h-4" /> Refresh
@@ -1351,6 +1402,7 @@ export function DatasetsPage() {
 												? prev.filter((c) => c !== col)
 												: [...prev, col],
 										);
+									const filteredCols = cleanSearch ? allCols.filter(c => c.toLowerCase().includes(cleanSearch.toLowerCase())) : allCols;
 									return (
 										<div className="space-y-1.5">
 											<div className="flex items-center justify-between">
@@ -1373,11 +1425,17 @@ export function DatasetsPage() {
 													</button>
 												</div>
 											</div>
+											<Input
+												placeholder="Search columns..."
+												value={cleanSearch}
+												onChange={(e) => setCleanSearch(e.target.value)}
+												className="h-8 text-xs"
+											/>
 											<p className="text-xs text-muted-foreground">
 												Leave all unselected to apply to every column.
 											</p>
 											<div className="rounded-lg border bg-muted/20 p-2 max-h-40 overflow-y-auto grid grid-cols-2 gap-1">
-												{allCols.map((col) => (
+												{filteredCols.map((col) => (
 													<label
 														key={col}
 														className="flex items-center gap-2 px-2 py-1.5 rounded-md hover:bg-muted/50 cursor-pointer text-xs"
@@ -1509,6 +1567,8 @@ export function DatasetsPage() {
 												: [...prev, col],
 										);
 
+									const filteredCols = transformSearch ? eligibleCols.filter(c => c.toLowerCase().includes(transformSearch.toLowerCase())) : eligibleCols;
+
 									return (
 										<div className="space-y-1.5">
 											<div className="flex items-center justify-between">
@@ -1536,8 +1596,14 @@ export function DatasetsPage() {
 													</button>
 												</div>
 											</div>
+											<Input
+												placeholder="Search columns..."
+												value={transformSearch}
+												onChange={(e) => setTransformSearch(e.target.value)}
+												className="h-8 text-xs"
+											/>
 											<div className="rounded-lg border bg-muted/20 p-2 max-h-44 overflow-y-auto grid grid-cols-2 gap-1">
-												{eligibleCols.map((col) => {
+												{filteredCols.map((col) => {
 													const dtype = dtypes[col] as string;
 													const isCat =
 														!dtype.includes("int") && !dtype.includes("float");

--- a/client/src/pages/DatasetsPage.tsx
+++ b/client/src/pages/DatasetsPage.tsx
@@ -1373,9 +1373,8 @@ export function DatasetsPage() {
 													{(() => {
 														const correlationDict =
 															explorerDs.dataset_metadata?.correlation;
-														const corrCols = correlationDict
-															? Object.keys(correlationDict)
-															: [];
+														if (!correlationDict) return null;
+														const corrCols = Object.keys(correlationDict);
 														if (corrCols.length < 2) return null;
 
 														return (

--- a/client/src/pages/DatasetsPage.tsx
+++ b/client/src/pages/DatasetsPage.tsx
@@ -132,9 +132,9 @@ export function DatasetsPage() {
 
 	// Explorer sheet state
 	const [explorerDs, setExplorerDs] = useState<Dataset | null>(null);
+	const [explorerTab, setExplorerTab] = useState("preview");
 
-	// Wrangle dialog state
-	const [wrangleDs, setWrangleDs] = useState<Dataset | null>(null);
+	// Wrangle tool state (integrated into Explorer)
 	const [isWrangling, setIsWrangling] = useState(false);
 	const [cleanStrategy, setCleanStrategy] = useState("drop_nulls");
 	const [cleanCols, setCleanCols] = useState<string[]>([]);
@@ -291,19 +291,19 @@ export function DatasetsPage() {
 	};
 
 	const handleClean = async () => {
-		if (!wrangleDs) return;
+		if (!explorerDs) return;
 		if (cleanStrategy === "drop_columns" && cleanCols.length === 0) {
 			toast.error("Select at least one column to drop");
 			return;
 		}
 		try {
 			setIsWrangling(true);
-			await api.post(`/dataset/${wrangleDs.id}/clean`, {
+			await api.post(`/dataset/${explorerDs.id}/clean`, {
 				strategy: cleanStrategy,
 				columns: cleanCols.length > 0 ? cleanCols : undefined,
 			});
 			toast.success("Dataset cleaned — new version created!");
-			setWrangleDs(null);
+			setExplorerDs(null);
 			await fetchDatasets();
 		} catch (error: any) {
 			toast.error(error.response?.data?.detail || "Clean failed");
@@ -313,7 +313,7 @@ export function DatasetsPage() {
 	};
 
 	const handleTransform = async () => {
-		if (!wrangleDs) return;
+		if (!explorerDs) return;
 		if (
 			(transformStrategy === "label_encoder" || transformStrategy === "one_hot_encoder") &&
 			transformCols.length === 0
@@ -321,7 +321,7 @@ export function DatasetsPage() {
 			toast.error("Select at least one column to encode");
 			return;
 		}
-		const meta = wrangleDs.dataset_metadata;
+		const meta = explorerDs.dataset_metadata;
 		const allCols = meta?.dtypes ? Object.keys(meta.dtypes) : [];
 		if (allCols.length === 0) {
 			toast.error("No columns found in dataset metadata");
@@ -329,12 +329,12 @@ export function DatasetsPage() {
 		}
 		try {
 			setIsWrangling(true);
-			await api.post(`/dataset/${wrangleDs.id}/transform`, {
+			await api.post(`/dataset/${explorerDs.id}/transform`, {
 				strategy: transformStrategy,
 				columns: transformCols.length > 0 ? transformCols : allCols,
 			});
 			toast.success("Dataset transformed — new version created!");
-			setWrangleDs(null);
+			setExplorerDs(null);
 			await fetchDatasets();
 		} catch (error: any) {
 			toast.error(error.response?.data?.detail || "Transform failed");
@@ -665,7 +665,7 @@ export function DatasetsPage() {
 										</DropdownMenuItem>
 										<DropdownMenuItem
 											className="gap-2"
-											onClick={() => setWrangleDs(ds)}
+											onClick={() => { setExplorerDs(ds); setExplorerTab("wrangle"); }}
 										>
 											<Wand2 className="w-4 h-4" /> Wrangle
 										</DropdownMenuItem>
@@ -760,7 +760,7 @@ export function DatasetsPage() {
 									variant="ghost"
 									size="sm"
 									className="flex-1 gap-2 text-muted-foreground hover:text-primary"
-									onClick={() => setWrangleDs(ds)}
+									onClick={() => { setExplorerDs(ds); setExplorerTab("wrangle"); }}
 								>
 									<Wand2 className="w-4 h-4" /> Wrangle
 								</Button>
@@ -990,8 +990,8 @@ export function DatasetsPage() {
 								))}
 							</div>
 
-							{/* Tabs: Preview / Columns / Stats */}
-							<Tabs defaultValue="preview">
+							{/* Tabs: Preview / Columns / Stats / Wrangle */}
+							<Tabs value={explorerTab} onValueChange={setExplorerTab}>
 								<TabsList className="mb-3 w-full">
 									<TabsTrigger value="preview" className="flex-1">
 										Preview
@@ -1001,6 +1001,9 @@ export function DatasetsPage() {
 									</TabsTrigger>
 									<TabsTrigger value="stats" className="flex-1">
 										Statistics
+									</TabsTrigger>
+									<TabsTrigger value="wrangle" className="flex-1">
+										Wrangle
 									</TabsTrigger>
 								</TabsList>
 
@@ -1300,19 +1303,310 @@ export function DatasetsPage() {
 										);
 									})()}
 								</TabsContent>
+								<TabsContent value="wrangle">
+									<div className="rounded-xl border bg-card text-card-foreground shadow-sm p-5 space-y-4">
+										<div>
+											<h3 className="text-lg font-semibold flex items-center gap-2">
+												<Wand2 className="w-5 h-5" /> Data Pipeline
+											</h3>
+											<p className="text-sm text-muted-foreground">
+												Configurations set here execute on the backend, generating a cleanly formatted derivative version of your dataset.
+											</p>
+										</div>
+										<Tabs defaultValue="clean" className="mt-2 w-full">
+											<TabsList className="w-full">
+												<TabsTrigger value="clean" className="flex-1">
+													Clean
+												</TabsTrigger>
+												<TabsTrigger value="transform" className="flex-1">
+													Transform
+												</TabsTrigger>
+											</TabsList>
+
+											{/* ── Clean tab ── */}
+											<TabsContent value="clean" className="space-y-4 pt-4 pb-2">
+												<div className="space-y-1.5">
+													<Label>Strategy</Label>
+													<Select
+														value={cleanStrategy}
+														onValueChange={setCleanStrategy}
+													>
+														<SelectTrigger>
+															<SelectValue />
+														</SelectTrigger>
+														<SelectContent>
+															{CLEAN_STRATEGIES.map((s) => (
+																<SelectItem key={s.value} value={s.value}>
+																	{s.label}
+																</SelectItem>
+															))}
+														</SelectContent>
+													</Select>
+												</div>
+
+												{/* Column picker for clean */}
+												{(() => {
+													const dtypes = explorerDs?.dataset_metadata?.dtypes ?? {};
+													const allCols = Object.keys(dtypes);
+													if (allCols.length === 0) return null;
+													const toggleCol = (col: string) =>
+														setCleanCols((prev) =>
+															prev.includes(col)
+																? prev.filter((c) => c !== col)
+																: [...prev, col],
+														);
+													const filteredCols = cleanSearch ? allCols.filter(c => c.toLowerCase().includes(cleanSearch.toLowerCase())) : allCols;
+													return (
+														<div className="space-y-1.5">
+															<div className="flex items-center justify-between">
+																<Label className="text-sm">Columns</Label>
+																<div className="flex gap-2 text-xs">
+																	<button
+																		type="button"
+																		className="text-primary hover:underline"
+																		onClick={() => setCleanCols(allCols)}
+																	>
+																		All
+																	</button>
+																	<span className="text-muted-foreground">·</span>
+																	<button
+																		type="button"
+																		className="text-muted-foreground hover:underline"
+																		onClick={() => setCleanCols([])}
+																	>
+																		None
+																	</button>
+																</div>
+															</div>
+															<Input
+																placeholder="Search columns..."
+																value={cleanSearch}
+																onChange={(e) => setCleanSearch(e.target.value)}
+																className="h-8 text-xs"
+															/>
+															<p className="text-xs text-muted-foreground">
+																Leave all unselected to apply to every column.
+															</p>
+															<div className="rounded-lg border bg-muted/20 p-2 max-h-40 overflow-y-auto grid grid-cols-2 gap-1">
+																{filteredCols.map((col) => (
+																	<label
+																		key={col}
+																		className="flex items-center gap-2 px-2 py-1.5 rounded-md hover:bg-muted/50 cursor-pointer text-xs"
+																	>
+																		<input
+																			type="checkbox"
+																			className="accent-primary w-3.5 h-3.5 shrink-0"
+																			checked={cleanCols.includes(col)}
+																			onChange={() => toggleCol(col)}
+																		/>
+																		<span className="truncate font-mono" title={col}>
+																			{col}
+																		</span>
+																		<span className="ml-auto text-muted-foreground shrink-0">
+																			{dtypes[col]}
+																		</span>
+																	</label>
+																))}
+															</div>
+															{cleanCols.length > 0 && (
+																<p className="text-xs text-primary">
+																	{cleanCols.length} column
+																	{cleanCols.length > 1 ? "s" : ""} selected
+																</p>
+															)}
+														</div>
+													);
+												})()}
+
+												<div className="flex justify-end pt-2 pb-1">
+													<Button onClick={handleClean} disabled={isWrangling}>
+														{isWrangling ? (
+															<>
+																<Loader2 className="w-4 h-4 mr-2 animate-spin" />{" "}
+																Executing Pipeline...
+															</>
+														) : (
+															"Apply Clean"
+														)}
+													</Button>
+												</div>
+											</TabsContent>
+
+											{/* ── Transform tab ── */}
+											<TabsContent value="transform" className="space-y-4 pt-4 pb-2">
+												<div className="space-y-1.5">
+													<Label>Strategy</Label>
+													<Select
+														value={transformStrategy}
+														onValueChange={(v) => {
+															setTransformStrategy(v);
+															const dtypes = explorerDs?.dataset_metadata?.dtypes ?? {};
+															if (v === "label_encoder") {
+																const catCols = Object.entries(dtypes)
+																	.filter(
+																		([, t]) =>
+																			!(t as string).includes("int") &&
+																			!(t as string).includes("float"),
+																	)
+																	.map(([c]) => c);
+																setTransformCols(catCols);
+															} else {
+																const numCols = Object.entries(dtypes)
+																	.filter(
+																		([, t]) =>
+																			(t as string).includes("int") ||
+																			(t as string).includes("float"),
+																	)
+																	.map(([c]) => c);
+																setTransformCols(numCols);
+															}
+														}}
+													>
+														<SelectTrigger>
+															<SelectValue />
+														</SelectTrigger>
+														<SelectContent>
+															{TRANSFORM_STRATEGIES.map((s) => (
+																<SelectItem key={s.value} value={s.value}>
+																	{s.label}
+																</SelectItem>
+															))}
+														</SelectContent>
+													</Select>
+													<p className="text-xs text-muted-foreground">
+														{transformStrategy === "label_encoder"
+															? "Encodes text/category columns as integers. Select the columns to encode."
+															: "Scales numeric columns. Select which columns to scale, or leave all selected."}
+													</p>
+												</div>
+
+												{/* Column picker for transform */}
+												{(() => {
+													const dtypes = explorerDs?.dataset_metadata?.dtypes ?? {};
+													const isLabelEncode = transformStrategy === "label_encoder" || transformStrategy === "one_hot_encoder";
+
+													const eligibleCols = isLabelEncode
+														? Object.keys(dtypes)
+														: Object.entries(dtypes)
+																.filter(
+																	([, t]) =>
+																		(t as string).includes("int") ||
+																		(t as string).includes("float"),
+																)
+																.map(([c]) => c);
+
+													if (eligibleCols.length === 0)
+														return (
+															<p className="text-xs text-muted-foreground">
+																No eligible columns found.
+															</p>
+														);
+
+													const toggleCol = (col: string) =>
+														setTransformCols((prev) =>
+															prev.includes(col)
+																? prev.filter((c) => c !== col)
+																: [...prev, col],
+														);
+
+													const filteredCols = transformSearch ? eligibleCols.filter(c => c.toLowerCase().includes(transformSearch.toLowerCase())) : eligibleCols;
+
+													return (
+														<div className="space-y-1.5">
+															<div className="flex items-center justify-between">
+																<Label className="text-sm">
+																	Columns
+																	{isLabelEncode && (
+																		<span className="text-destructive ml-1">*</span>
+																	)}
+																</Label>
+																<div className="flex gap-2 text-xs">
+																	<button
+																		type="button"
+																		className="text-primary hover:underline"
+																		onClick={() => setTransformCols(eligibleCols)}
+																	>
+																		All
+																	</button>
+																	<span className="text-muted-foreground">·</span>
+																	<button
+																		type="button"
+																		className="text-muted-foreground hover:underline"
+																		onClick={() => setTransformCols([])}
+																	>
+																		None
+																	</button>
+																</div>
+															</div>
+															<Input
+																placeholder="Search columns..."
+																value={transformSearch}
+																onChange={(e) => setTransformSearch(e.target.value)}
+																className="h-8 text-xs"
+															/>
+															<div className="rounded-lg border bg-muted/20 p-2 max-h-44 overflow-y-auto grid grid-cols-2 gap-1">
+																{filteredCols.map((col) => {
+																	const dtype = dtypes[col] as string;
+																	const isCat =
+																		!dtype.includes("int") && !dtype.includes("float");
+																	return (
+																		<label
+																			key={col}
+																			className="flex items-center gap-2 px-2 py-1.5 rounded-md hover:bg-muted/50 cursor-pointer text-xs"
+																		>
+																			<input
+																				type="checkbox"
+																				className="accent-primary w-3.5 h-3.5 shrink-0"
+																				checked={transformCols.includes(col)}
+																				onChange={() => toggleCol(col)}
+																			/>
+																			<span className="truncate font-mono" title={col}>
+																				{col}
+																			</span>
+																			<Badge
+																				variant="outline"
+																				className={`ml-auto text-[10px] px-1 py-0 h-4 shrink-0 ${isCat ? "border-amber-500/40 text-amber-400" : "border-blue-500/40 text-blue-400"}`}
+																			>
+																				{isCat ? "cat" : "num"}
+																			</Badge>
+																		</label>
+																	);
+																})}
+															</div>
+															{transformCols.length > 0 ? (
+																<p className="text-xs text-primary">
+																	{transformCols.length} column
+																	{transformCols.length > 1 ? "s" : ""} selected
+																</p>
+															) : isLabelEncode ? (
+																<p className="text-xs text-destructive">
+																	At least one column must be selected
+																</p>
+															) : null}
+														</div>
+													);
+												})()}
+
+												<div className="flex justify-end pt-2 pb-1">
+													<Button onClick={handleTransform} disabled={isWrangling}>
+														{isWrangling ? (
+															<>
+																<Loader2 className="w-4 h-4 mr-2 animate-spin" />{" "}
+																Executing Pipeline...
+															</>
+														) : (
+															"Apply Transform"
+														)}
+													</Button>
+												</div>
+											</TabsContent>
+										</Tabs>
+									</div>
+								</TabsContent>
 							</Tabs>
 							</div>
 
 							<div className="mt-4 pt-4 border-t flex gap-2 shrink-0 bg-background">
-								<Button
-									className="gap-2 flex-1 shadow-sm"
-									onClick={() => {
-										setWrangleDs(explorerDs);
-										setExplorerDs(null);
-									}}
-								>
-									<Wand2 className="w-4 h-4" /> Wrangle
-								</Button>
 								<Button
 									variant="outline"
 									className="gap-2 shadow-sm"
@@ -1321,354 +1615,20 @@ export function DatasetsPage() {
 										setExplorerDs(null);
 									}}
 								>
-									<Pencil className="w-4 h-4" /> Edit
+									<Pencil className="w-4 h-4" /> Edit Details
 								</Button>
 								<Button
 									variant="outline"
 									className="gap-2 shadow-sm"
 									onClick={() => handleRefresh(explorerDs.id, explorerDs.name)}
 								>
-									<RefreshCw className="w-4 h-4" /> Refresh
+									<RefreshCw className="w-4 h-4" /> Hard Refresh
 								</Button>
 							</div>
 						</>
 					)}
 				</SheetContent>
 			</Sheet>
-
-			{/* ── Wrangle Dialog (Clean & Transform) ──────────────────── */}
-			<Dialog
-				open={!!wrangleDs}
-				onOpenChange={(o) => {
-					if (!o) {
-						setWrangleDs(null);
-						setCleanCols([]);
-						setTransformCols([]);
-						setTransformStrategy("standard_scaler");
-						setCleanStrategy("drop_nulls");
-					}
-				}}
-			>
-				<DialogContent className="sm:max-w-[500px] flex flex-col max-h-[85vh] p-0 overflow-hidden">
-					<DialogHeader className="shrink-0 p-6 pb-3">
-						<DialogTitle className="flex items-center gap-2">
-							<Wand2 className="w-5 h-5" /> Wrangle — {wrangleDs?.name}
-						</DialogTitle>
-						<DialogDescription>
-							A new versioned dataset is created after each operation.
-						</DialogDescription>
-					</DialogHeader>
-
-					<div className="flex-1 overflow-y-auto px-6">
-						<Tabs defaultValue="clean" className="mt-2">
-							<TabsList className="w-full">
-								<TabsTrigger value="clean" className="flex-1">
-									Clean
-								</TabsTrigger>
-								<TabsTrigger value="transform" className="flex-1">
-									Transform
-								</TabsTrigger>
-							</TabsList>
-
-							{/* ── Clean tab ── */}
-							<TabsContent value="clean" className="space-y-4 pt-4 pb-2">
-								<div className="space-y-1.5">
-									<Label>Strategy</Label>
-									<Select
-										value={cleanStrategy}
-										onValueChange={setCleanStrategy}
-									>
-										<SelectTrigger>
-											<SelectValue />
-										</SelectTrigger>
-										<SelectContent>
-											{CLEAN_STRATEGIES.map((s) => (
-												<SelectItem key={s.value} value={s.value}>
-													{s.label}
-												</SelectItem>
-											))}
-										</SelectContent>
-									</Select>
-								</div>
-
-								{/* Column picker for clean */}
-								{(() => {
-									const dtypes = wrangleDs?.dataset_metadata?.dtypes ?? {};
-									const allCols = Object.keys(dtypes);
-									if (allCols.length === 0) return null;
-									const toggleCol = (col: string) =>
-										setCleanCols((prev) =>
-											prev.includes(col)
-												? prev.filter((c) => c !== col)
-												: [...prev, col],
-										);
-									const filteredCols = cleanSearch ? allCols.filter(c => c.toLowerCase().includes(cleanSearch.toLowerCase())) : allCols;
-									return (
-										<div className="space-y-1.5">
-											<div className="flex items-center justify-between">
-												<Label className="text-sm">Columns</Label>
-												<div className="flex gap-2 text-xs">
-													<button
-														type="button"
-														className="text-primary hover:underline"
-														onClick={() => setCleanCols(allCols)}
-													>
-														All
-													</button>
-													<span className="text-muted-foreground">·</span>
-													<button
-														type="button"
-														className="text-muted-foreground hover:underline"
-														onClick={() => setCleanCols([])}
-													>
-														None
-													</button>
-												</div>
-											</div>
-											<Input
-												placeholder="Search columns..."
-												value={cleanSearch}
-												onChange={(e) => setCleanSearch(e.target.value)}
-												className="h-8 text-xs"
-											/>
-											<p className="text-xs text-muted-foreground">
-												Leave all unselected to apply to every column.
-											</p>
-											<div className="rounded-lg border bg-muted/20 p-2 max-h-40 overflow-y-auto grid grid-cols-2 gap-1">
-												{filteredCols.map((col) => (
-													<label
-														key={col}
-														className="flex items-center gap-2 px-2 py-1.5 rounded-md hover:bg-muted/50 cursor-pointer text-xs"
-													>
-														<input
-															type="checkbox"
-															className="accent-primary w-3.5 h-3.5 shrink-0"
-															checked={cleanCols.includes(col)}
-															onChange={() => toggleCol(col)}
-														/>
-														<span className="truncate font-mono" title={col}>
-															{col}
-														</span>
-														<span className="ml-auto text-muted-foreground shrink-0">
-															{dtypes[col]}
-														</span>
-													</label>
-												))}
-											</div>
-											{cleanCols.length > 0 && (
-												<p className="text-xs text-primary">
-													{cleanCols.length} column
-													{cleanCols.length > 1 ? "s" : ""} selected
-												</p>
-											)}
-										</div>
-									);
-								})()}
-
-								<div className="flex justify-end gap-2 pt-2 pb-1">
-									<Button
-										variant="outline"
-										onClick={() => setWrangleDs(null)}
-										disabled={isWrangling}
-									>
-										Cancel
-									</Button>
-									<Button onClick={handleClean} disabled={isWrangling}>
-										{isWrangling ? (
-											<>
-												<Loader2 className="w-4 h-4 mr-2 animate-spin" />{" "}
-												Cleaning...
-											</>
-										) : (
-											"Apply Clean"
-										)}
-									</Button>
-								</div>
-							</TabsContent>
-
-							{/* ── Transform tab ── */}
-							<TabsContent value="transform" className="space-y-4 pt-4 pb-2">
-								<div className="space-y-1.5">
-									<Label>Strategy</Label>
-									<Select
-										value={transformStrategy}
-										onValueChange={(v) => {
-											setTransformStrategy(v);
-											// Auto-select sensible defaults when switching strategy
-											const dtypes = wrangleDs?.dataset_metadata?.dtypes ?? {};
-											if (v === "label_encoder") {
-												// Pre-select categorical (non-numeric) columns
-												const catCols = Object.entries(dtypes)
-													.filter(
-														([, t]) =>
-															!(t as string).includes("int") &&
-															!(t as string).includes("float"),
-													)
-													.map(([c]) => c);
-												setTransformCols(catCols);
-											} else {
-												// Pre-select numeric columns for scalers
-												const numCols = Object.entries(dtypes)
-													.filter(
-														([, t]) =>
-															(t as string).includes("int") ||
-															(t as string).includes("float"),
-													)
-													.map(([c]) => c);
-												setTransformCols(numCols);
-											}
-										}}
-									>
-										<SelectTrigger>
-											<SelectValue />
-										</SelectTrigger>
-										<SelectContent>
-											{TRANSFORM_STRATEGIES.map((s) => (
-												<SelectItem key={s.value} value={s.value}>
-													{s.label}
-												</SelectItem>
-											))}
-										</SelectContent>
-									</Select>
-									<p className="text-xs text-muted-foreground">
-										{transformStrategy === "label_encoder"
-											? "Encodes text/category columns as integers. Select the columns to encode."
-											: "Scales numeric columns. Select which columns to scale, or leave all selected."}
-									</p>
-								</div>
-
-								{/* Column picker for transform */}
-								{(() => {
-									const dtypes = wrangleDs?.dataset_metadata?.dtypes ?? {};
-									const isLabelEncode = transformStrategy === "label_encoder";
-
-									// For label encoder show all cols, for scalers show only numeric
-									const eligibleCols = isLabelEncode
-										? Object.keys(dtypes)
-										: Object.entries(dtypes)
-												.filter(
-													([, t]) =>
-														(t as string).includes("int") ||
-														(t as string).includes("float"),
-												)
-												.map(([c]) => c);
-
-									if (eligibleCols.length === 0)
-										return (
-											<p className="text-xs text-muted-foreground">
-												No eligible columns found.
-											</p>
-										);
-
-									const toggleCol = (col: string) =>
-										setTransformCols((prev) =>
-											prev.includes(col)
-												? prev.filter((c) => c !== col)
-												: [...prev, col],
-										);
-
-									const filteredCols = transformSearch ? eligibleCols.filter(c => c.toLowerCase().includes(transformSearch.toLowerCase())) : eligibleCols;
-
-									return (
-										<div className="space-y-1.5">
-											<div className="flex items-center justify-between">
-												<Label className="text-sm">
-													Columns
-													{isLabelEncode && (
-														<span className="text-destructive ml-1">*</span>
-													)}
-												</Label>
-												<div className="flex gap-2 text-xs">
-													<button
-														type="button"
-														className="text-primary hover:underline"
-														onClick={() => setTransformCols(eligibleCols)}
-													>
-														All
-													</button>
-													<span className="text-muted-foreground">·</span>
-													<button
-														type="button"
-														className="text-muted-foreground hover:underline"
-														onClick={() => setTransformCols([])}
-													>
-														None
-													</button>
-												</div>
-											</div>
-											<Input
-												placeholder="Search columns..."
-												value={transformSearch}
-												onChange={(e) => setTransformSearch(e.target.value)}
-												className="h-8 text-xs"
-											/>
-											<div className="rounded-lg border bg-muted/20 p-2 max-h-44 overflow-y-auto grid grid-cols-2 gap-1">
-												{filteredCols.map((col) => {
-													const dtype = dtypes[col] as string;
-													const isCat =
-														!dtype.includes("int") && !dtype.includes("float");
-													return (
-														<label
-															key={col}
-															className="flex items-center gap-2 px-2 py-1.5 rounded-md hover:bg-muted/50 cursor-pointer text-xs"
-														>
-															<input
-																type="checkbox"
-																className="accent-primary w-3.5 h-3.5 shrink-0"
-																checked={transformCols.includes(col)}
-																onChange={() => toggleCol(col)}
-															/>
-															<span className="truncate font-mono" title={col}>
-																{col}
-															</span>
-															<Badge
-																variant="outline"
-																className={`ml-auto text-[10px] px-1 py-0 h-4 shrink-0 ${isCat ? "border-amber-500/40 text-amber-400" : "border-blue-500/40 text-blue-400"}`}
-															>
-																{isCat ? "cat" : "num"}
-															</Badge>
-														</label>
-													);
-												})}
-											</div>
-											{transformCols.length > 0 ? (
-												<p className="text-xs text-primary">
-													{transformCols.length} column
-													{transformCols.length > 1 ? "s" : ""} selected
-												</p>
-											) : isLabelEncode ? (
-												<p className="text-xs text-destructive">
-													At least one column must be selected
-												</p>
-											) : null}
-										</div>
-									);
-								})()}
-
-								<div className="flex justify-end gap-2 pt-2 pb-1">
-									<Button
-										variant="outline"
-										onClick={() => setWrangleDs(null)}
-										disabled={isWrangling}
-									>
-										Cancel
-									</Button>
-									<Button onClick={handleTransform} disabled={isWrangling}>
-										{isWrangling ? (
-											<>
-												<Loader2 className="w-4 h-4 mr-2 animate-spin" />{" "}
-												Transforming...
-											</>
-										) : (
-											"Apply Transform"
-										)}
-									</Button>
-								</div>
-							</TabsContent>
-						</Tabs>
-					</div>
-				</DialogContent>
-			</Dialog>
 		</div>
 	);
 }

--- a/client/src/pages/ModelsPage.tsx
+++ b/client/src/pages/ModelsPage.tsx
@@ -18,6 +18,7 @@ import {
 	SheetHeader,
 	SheetTitle,
 	SheetDescription,
+	SheetTrigger,
 } from "@/components/ui/sheet";
 import {
 	Card,
@@ -77,6 +78,7 @@ import { toast } from "sonner";
 interface Dataset {
 	id: string;
 	name: string;
+	dataset_metadata?: any;
 }
 
 interface MLModel {
@@ -368,12 +370,30 @@ function TrainFormFields({
 }: {
 	form: typeof EMPTY_FORM;
 	setForm: (f: typeof EMPTY_FORM) => void;
-	datasets: { id: string; name: string }[];
+	datasets: Dataset[];
 	schemas: HyperparamDef[];
 	hyperparams: Record<string, any>;
 	setHyperparams: (h: Record<string, any>) => void;
 	isLoadingSchemas: boolean;
 }) {
+	const [featureSearch, setFeatureSearch] = useState("");
+	
+	const activeDataset = datasets.find((d) => d.id === form.dataset_id);
+	const dtypes = activeDataset?.dataset_metadata?.dtypes ?? {};
+	const allCols = Object.keys(dtypes);
+
+	// Parse current form.features string into array
+	const selectedFeatures = form.features 
+		? form.features.split(',').map(f => f.trim()).filter(Boolean) 
+		: [];
+
+	const toggleFeature = (col: string) => {
+		const newFeatures = selectedFeatures.includes(col)
+			? selectedFeatures.filter(c => c !== col)
+			: [...selectedFeatures, col];
+		setForm({ ...form, features: newFeatures.join(",") });
+	};
+
 	return (
 		<div className="grid gap-4 py-2">
 			{/* Name */}
@@ -461,31 +481,124 @@ function TrainFormFields({
 
 			{/* Target column */}
 			<div className="space-y-1.5">
-				<Label htmlFor="target">
+				<Label>
 					Target Column <span className="text-destructive">*</span>
 				</Label>
-				<Input
-					id="target"
-					placeholder="e.g. price, label, species"
-					value={form.target_column}
-					onChange={(e) => setForm({ ...form, target_column: e.target.value })}
-				/>
+				{allCols.length > 0 ? (
+					<Select
+						value={form.target_column}
+						onValueChange={(v) => {
+							// If they pick a target that is currently a feature, remove it from features
+							let updatedFeatures = selectedFeatures;
+							if (selectedFeatures.includes(v)) {
+								updatedFeatures = selectedFeatures.filter(f => f !== v);
+							}
+							setForm({ ...form, target_column: v, features: updatedFeatures.join(",") });
+						}}
+					>
+						<SelectTrigger>
+							<SelectValue placeholder="Select target..." />
+						</SelectTrigger>
+						<SelectContent>
+							{allCols.map((c) => (
+								<SelectItem key={c} value={c}>
+									{c}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+				) : (
+					<Input
+						placeholder="Select a dataset first"
+						disabled
+					/>
+				)}
 			</div>
 
 			{/* Features */}
 			<div className="space-y-1.5">
-				<Label htmlFor="features">
-					Feature Columns{" "}
-					<span className="text-muted-foreground text-xs">
-						(optional, comma-separated)
-					</span>
-				</Label>
-				<Input
-					id="features"
-					placeholder="e.g. col1, col2 — leave blank to use all"
-					value={form.features}
-					onChange={(e) => setForm({ ...form, features: e.target.value })}
-				/>
+				<div className="flex items-center justify-between">
+					<Label>
+						Feature Columns{" "}
+						<span className="text-muted-foreground text-xs">
+							(optional)
+						</span>
+					</Label>
+					{allCols.length > 0 && (
+						<div className="flex gap-2 text-xs">
+							<button
+								type="button"
+								className="text-primary hover:underline"
+								onClick={() => {
+									const featuresOnly = allCols.filter(c => c !== form.target_column);
+									setForm({ ...form, features: featuresOnly.join(",") });
+								}}
+							>
+								All
+							</button>
+							<span className="text-muted-foreground">·</span>
+							<button
+								type="button"
+								className="text-muted-foreground hover:underline"
+								onClick={() => setForm({ ...form, features: "" })}
+							>
+								None
+							</button>
+						</div>
+					)}
+				</div>
+				
+				{allCols.length > 0 ? (
+					<>
+						<Input
+							placeholder="Search features..."
+							value={featureSearch}
+							onChange={(e) => setFeatureSearch(e.target.value)}
+							className="h-8 text-xs"
+						/>
+						<p className="text-xs text-muted-foreground mb-1">
+							Leave explicitly empty to automatically use all non-target columns.
+						</p>
+						<div className="rounded-lg border bg-muted/20 p-2 max-h-40 overflow-y-auto grid grid-cols-2 gap-1">
+							{allCols
+								.filter(c => c !== form.target_column) // Can't use target as feature
+								.filter(c => featureSearch ? c.toLowerCase().includes(featureSearch.toLowerCase()) : true)
+								.map((col) => (
+								<label
+									key={col}
+									className="flex items-center gap-2 px-2 py-1.5 rounded-md hover:bg-muted/50 cursor-pointer text-xs"
+								>
+									<input
+										type="checkbox"
+										className="accent-primary w-3.5 h-3.5 shrink-0"
+										checked={selectedFeatures.includes(col)}
+										onChange={() => toggleFeature(col)}
+									/>
+									<span className="truncate font-mono" title={col}>
+										{col}
+									</span>
+									<Badge
+										variant="outline"
+										className={`ml-auto text-[10px] px-1 py-0 h-4 shrink-0 ${!((dtypes[col] as string)?.includes('int') || (dtypes[col] as string)?.includes('float')) ? "border-amber-500/40 text-amber-400" : "border-blue-500/40 text-blue-400"}`}
+									>
+										{!((dtypes[col] as string)?.includes('int') || (dtypes[col] as string)?.includes('float')) ? "cat" : "num"}
+									</Badge>
+								</label>
+							))}
+						</div>
+						{selectedFeatures.length > 0 && (
+							<p className="text-xs text-primary">
+								{selectedFeatures.length} feature
+								{selectedFeatures.length > 1 ? "s" : ""} selected
+							</p>
+						)}
+					</>
+				) : (
+					<Input
+						placeholder="Select a dataset to pick features"
+						disabled
+					/>
+				)}
 			</div>
 
 			{/* Hyperparameters */}
@@ -503,8 +616,7 @@ function TrainFormFields({
 						</p>
 					)}
 					{!isLoadingSchemas && schemas.length > 0 && (
-						<ScrollArea className="max-h-52 pr-2">
-							<div className="space-y-3">
+						<div className="pr-2 space-y-3">
 								{schemas.map((s) => (
 									<HyperparamField
 										key={s.name}
@@ -515,8 +627,7 @@ function TrainFormFields({
 										}
 									/>
 								))}
-							</div>
-						</ScrollArea>
+						</div>
 					)}
 				</div>
 			)}
@@ -919,20 +1030,23 @@ export function ModelsPage() {
 							className={`w-4 h-4 ${isLoading ? "animate-spin" : ""}`}
 						/>
 					</Button>
-					<Dialog open={isTrainOpen} onOpenChange={setIsTrainOpen}>
-						<DialogTrigger asChild>
+					<Sheet open={isTrainOpen} onOpenChange={setIsTrainOpen}>
+						<SheetTrigger asChild>
 							<Button className="gap-2">
 								<Plus className="w-4 h-4" /> Train Model
 							</Button>
-						</DialogTrigger>
-						<DialogContent className="sm:max-w-[520px] flex flex-col max-h-[85vh] p-0 overflow-hidden">
-							<DialogHeader className="shrink-0 p-6 pb-3">
-								<DialogTitle>Train a New Model</DialogTitle>
-								<DialogDescription>
-									Select a dataset, algorithm, and tune hyperparameters.
-								</DialogDescription>
-							</DialogHeader>
-							<div className="flex-1 overflow-y-auto px-6">
+						</SheetTrigger>
+						<SheetContent className="sm:max-w-[500px] flex flex-col p-0">
+							<div className="p-6 pb-2 shrink-0">
+								<SheetHeader>
+									<SheetTitle>Train New Model</SheetTitle>
+									<SheetDescription>
+										Select an algorithm and map your target column to begin training.
+									</SheetDescription>
+								</SheetHeader>
+							</div>
+
+							<div className="flex-1 overflow-y-auto px-6 pb-6">
 								<TrainFormFields
 									form={trainForm}
 									setForm={setTrainForm}
@@ -943,19 +1057,12 @@ export function ModelsPage() {
 									isLoadingSchemas={isLoadingTrainSchemas}
 								/>
 							</div>
-							<DialogFooter className="shrink-0 border-t border-border/60 px-6 py-4 mt-0">
-								<Button
-									variant="outline"
-									onClick={() => setIsTrainOpen(false)}
-									disabled={isTraining}
-								>
-									Cancel
-								</Button>
-								<Button onClick={handleTrain} disabled={isTraining}>
+							<div className="shrink-0 border-t p-4 bg-background flex flex-col gap-2">
+								<Button onClick={handleTrain} disabled={isTraining} className="w-full">
 									{isTraining ? (
 										<>
 											<Loader2 className="w-4 h-4 mr-2 animate-spin" />{" "}
-											Training...
+											Training Pipeline Active...
 										</>
 									) : (
 										<>
@@ -963,9 +1070,17 @@ export function ModelsPage() {
 										</>
 									)}
 								</Button>
-							</DialogFooter>
-						</DialogContent>
-					</Dialog>
+								<Button
+									variant="outline"
+									onClick={() => setIsTrainOpen(false)}
+									disabled={isTraining}
+									className="w-full"
+								>
+									Cancel
+								</Button>
+							</div>
+						</SheetContent>
+					</Sheet>
 				</div>
 			</div>
 
@@ -1416,21 +1531,23 @@ export function ModelsPage() {
 			</Dialog>
 
 			{/* ── Retrain Dialog ─────────────────────────────────────── */}
-			<Dialog
+			<Sheet
 				open={!!retrainModel}
 				onOpenChange={(o) => !o && setRetrainModel(null)}
 			>
-				<DialogContent className="sm:max-w-[520px] flex flex-col max-h-[85vh] p-0 overflow-hidden">
-					<DialogHeader className="shrink-0 p-6 pb-3">
-						<DialogTitle className="flex items-center gap-2">
-							<FlaskConical className="w-5 h-5" /> Retrain —{" "}
-							{retrainModel?.name}
-						</DialogTitle>
-						<DialogDescription>
-							Creates a new version. Current: v{retrainModel?.version}
-						</DialogDescription>
-					</DialogHeader>
-					<div className="flex-1 overflow-y-auto px-6">
+				<SheetContent className="sm:max-w-[500px] flex flex-col p-0">
+					<div className="p-6 pb-2 shrink-0">
+						<SheetHeader>
+							<SheetTitle className="flex items-center gap-2">
+								<FlaskConical className="w-5 h-5" /> Retrain —{" "}
+								{retrainModel?.name}
+							</SheetTitle>
+							<SheetDescription>
+								Creates a new version. Current: v{retrainModel?.version}
+							</SheetDescription>
+						</SheetHeader>
+					</div>
+					<div className="flex-1 overflow-y-auto px-6 pb-6">
 						<TrainFormFields
 							form={retrainForm}
 							setForm={setRetrainForm}
@@ -1441,15 +1558,8 @@ export function ModelsPage() {
 							isLoadingSchemas={isLoadingRetrainSchemas}
 						/>
 					</div>
-					<DialogFooter className="shrink-0 border-t border-border/60 px-6 py-4">
-						<Button
-							variant="outline"
-							onClick={() => setRetrainModel(null)}
-							disabled={isRetraining}
-						>
-							Cancel
-						</Button>
-						<Button onClick={handleRetrain} disabled={isRetraining}>
+					<div className="shrink-0 border-t p-4 bg-background flex flex-col gap-2">
+						<Button onClick={handleRetrain} disabled={isRetraining} className="w-full">
 							{isRetraining ? (
 								<>
 									<Loader2 className="w-4 h-4 mr-2 animate-spin" />{" "}
@@ -1461,9 +1571,17 @@ export function ModelsPage() {
 								</>
 							)}
 						</Button>
-					</DialogFooter>
-				</DialogContent>
-			</Dialog>
+						<Button
+							variant="outline"
+							onClick={() => setRetrainModel(null)}
+							disabled={isRetraining}
+							className="w-full"
+						>
+							Cancel
+						</Button>
+					</div>
+				</SheetContent>
+			</Sheet>
 
 			{/* ── Lineage Sheet ──────────────────────────────────────── */}
 			<Sheet

--- a/client/src/pages/ModelsPage.tsx
+++ b/client/src/pages/ModelsPage.tsx
@@ -309,22 +309,25 @@ function PredictInputs({
 				</button>
 			</div>
 
-			{/* Two-column grid */}
-			<div className="grid grid-cols-2 gap-x-4 gap-y-2.5">
+			{/* Form inputs grid */}
+			<div className="rounded-xl border border-border/50 bg-card overflow-hidden divide-y divide-border/50">
 				{filtered.map((col) => (
-					<div key={col} className="space-y-1">
+					<div key={col} className="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-4 p-3 hover:bg-muted/10 transition-colors">
 						<Label
-							className="text-[11px] font-mono text-muted-foreground truncate block"
+							className="text-xs sm:text-sm font-medium font-mono text-muted-foreground sm:w-[40%] shrink-0 truncate flex items-center gap-2"
 							title={col}
 						>
+							<div className="w-1.5 h-1.5 rounded-full bg-primary/40 shrink-0" />
 							{col}
 						</Label>
-						<Input
-							className="h-7 text-xs"
-							placeholder="value"
-							value={inputs[col]}
-							onChange={(e) => onChange(col, e.target.value)}
-						/>
+						<div className="flex-1 min-w-0">
+							<Input
+								className="h-8 text-sm"
+								placeholder={`Enter value...`}
+								value={inputs[col]}
+								onChange={(e) => onChange(col, e.target.value)}
+							/>
+						</div>
 					</div>
 				))}
 			</div>
@@ -1367,8 +1370,8 @@ export function ModelsPage() {
 				</DialogContent>
 			</Dialog>
 
-			{/* ── Predict / Test Dialog ─────────────────────────────── */}
-			<Dialog
+			{/* ── Predict / Test Sheet ─────────────────────────────── */}
+			<Sheet
 				open={!!predictModel}
 				onOpenChange={(o) => {
 					if (!o) {
@@ -1378,22 +1381,24 @@ export function ModelsPage() {
 					}
 				}}
 			>
-				<DialogContent className="sm:max-w-[520px] flex flex-col max-h-[85vh] p-0 overflow-hidden">
-					<DialogHeader className="shrink-0 p-6 pb-3">
-						<DialogTitle className="flex items-center gap-2">
-							<TestTube2 className="w-5 h-5" /> Test — {predictModel?.name}
-							<Badge variant="secondary" className="ml-auto text-xs font-mono">
-								{Object.keys(predictInputs).length} feature
-								{Object.keys(predictInputs).length !== 1 ? "s" : ""}
-							</Badge>
-						</DialogTitle>
-						<DialogDescription>
-							Enter feature values to run a single-row prediction. Target:{" "}
-							<span className="font-medium text-foreground">
-								{predictModel?.outputs}
-							</span>
-						</DialogDescription>
-					</DialogHeader>
+				<SheetContent className="sm:max-w-[500px] flex flex-col p-0">
+					<div className="p-6 pb-2 shrink-0">
+						<SheetHeader>
+							<SheetTitle className="flex items-center gap-2">
+								<TestTube2 className="w-5 h-5" /> Test — {predictModel?.name}
+								<Badge variant="secondary" className="ml-auto text-xs font-mono">
+									{Object.keys(predictInputs).length} feature
+									{Object.keys(predictInputs).length !== 1 ? "s" : ""}
+								</Badge>
+							</SheetTitle>
+							<SheetDescription>
+								Enter feature values to run a single-row prediction. Target:{" "}
+								<span className="font-medium text-foreground">
+									{predictModel?.outputs}
+								</span>
+							</SheetDescription>
+						</SheetHeader>
+					</div>
 
 					<div className="flex-1 overflow-y-auto px-6 pb-2">
 						{/* Input fields */}
@@ -1473,45 +1478,27 @@ export function ModelsPage() {
 						)}
 					</div>
 
-					<div className="shrink-0 border-t border-border/60 px-6 py-4 flex justify-between items-center gap-2">
+					<div className="shrink-0 border-t p-4 bg-background flex flex-col gap-2">
 						{predictResult ? (
-							<>
-								<Button
-									variant="outline"
-									size="sm"
-									onClick={() => setPredictResult(null)}
-								>
-									← Edit inputs
-								</Button>
-								<Button
-									variant="outline"
-									onClick={() => {
-										setPredictModel(null);
-										setPredictResult(null);
-										setPredictInputs({});
-									}}
-								>
-									Close
-								</Button>
-							</>
+							<Button
+								variant="outline"
+								onClick={() => {
+									setPredictModel(null);
+									setPredictResult(null);
+									setPredictInputs({});
+								}}
+								className="w-full"
+							>
+								Close
+							</Button>
 						) : (
 							<>
-								<Button
-									variant="outline"
-									onClick={() => {
-										setPredictModel(null);
-										setPredictResult(null);
-										setPredictInputs({});
-									}}
-									disabled={isPredicting}
-								>
-									Cancel
-								</Button>
 								<Button
 									onClick={handlePredict}
 									disabled={
 										isPredicting || Object.keys(predictInputs).length === 0
 									}
+									className="w-full"
 								>
 									{isPredicting ? (
 										<>
@@ -1524,11 +1511,23 @@ export function ModelsPage() {
 										</>
 									)}
 								</Button>
+								<Button
+									variant="outline"
+									onClick={() => {
+										setPredictModel(null);
+										setPredictResult(null);
+										setPredictInputs({});
+									}}
+									disabled={isPredicting}
+									className="w-full"
+								>
+									Cancel
+								</Button>
 							</>
 						)}
 					</div>
-				</DialogContent>
-			</Dialog>
+				</SheetContent>
+			</Sheet>
 
 			{/* ── Retrain Dialog ─────────────────────────────────────── */}
 			<Sheet

--- a/client/src/pages/ModelsPage.tsx
+++ b/client/src/pages/ModelsPage.tsx
@@ -10,7 +10,6 @@ import {
 	DialogTitle,
 	DialogDescription,
 	DialogFooter,
-	DialogTrigger,
 } from "@/components/ui/dialog";
 import {
 	Sheet,
@@ -53,7 +52,6 @@ import {
 	TooltipProvider,
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import {
 	Library,
 	MoreVertical,
@@ -312,7 +310,10 @@ function PredictInputs({
 			{/* Form inputs grid */}
 			<div className="rounded-xl border border-border/50 bg-card overflow-hidden divide-y divide-border/50">
 				{filtered.map((col) => (
-					<div key={col} className="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-4 p-3 hover:bg-muted/10 transition-colors">
+					<div
+						key={col}
+						className="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-4 p-3 hover:bg-muted/10 transition-colors"
+					>
 						<Label
 							className="text-xs sm:text-sm font-medium font-mono text-muted-foreground sm:w-[40%] shrink-0 truncate flex items-center gap-2"
 							title={col}
@@ -380,19 +381,22 @@ function TrainFormFields({
 	isLoadingSchemas: boolean;
 }) {
 	const [featureSearch, setFeatureSearch] = useState("");
-	
+
 	const activeDataset = datasets.find((d) => d.id === form.dataset_id);
 	const dtypes = activeDataset?.dataset_metadata?.dtypes ?? {};
 	const allCols = Object.keys(dtypes);
 
 	// Parse current form.features string into array
-	const selectedFeatures = form.features 
-		? form.features.split(',').map(f => f.trim()).filter(Boolean) 
+	const selectedFeatures = form.features
+		? form.features
+				.split(",")
+				.map((f) => f.trim())
+				.filter(Boolean)
 		: [];
 
 	const toggleFeature = (col: string) => {
 		const newFeatures = selectedFeatures.includes(col)
-			? selectedFeatures.filter(c => c !== col)
+			? selectedFeatures.filter((c) => c !== col)
 			: [...selectedFeatures, col];
 		setForm({ ...form, features: newFeatures.join(",") });
 	};
@@ -494,9 +498,13 @@ function TrainFormFields({
 							// If they pick a target that is currently a feature, remove it from features
 							let updatedFeatures = selectedFeatures;
 							if (selectedFeatures.includes(v)) {
-								updatedFeatures = selectedFeatures.filter(f => f !== v);
+								updatedFeatures = selectedFeatures.filter((f) => f !== v);
 							}
-							setForm({ ...form, target_column: v, features: updatedFeatures.join(",") });
+							setForm({
+								...form,
+								target_column: v,
+								features: updatedFeatures.join(","),
+							});
 						}}
 					>
 						<SelectTrigger>
@@ -511,10 +519,7 @@ function TrainFormFields({
 						</SelectContent>
 					</Select>
 				) : (
-					<Input
-						placeholder="Select a dataset first"
-						disabled
-					/>
+					<Input placeholder="Select a dataset first" disabled />
 				)}
 			</div>
 
@@ -523,9 +528,7 @@ function TrainFormFields({
 				<div className="flex items-center justify-between">
 					<Label>
 						Feature Columns{" "}
-						<span className="text-muted-foreground text-xs">
-							(optional)
-						</span>
+						<span className="text-muted-foreground text-xs">(optional)</span>
 					</Label>
 					{allCols.length > 0 && (
 						<div className="flex gap-2 text-xs">
@@ -533,7 +536,9 @@ function TrainFormFields({
 								type="button"
 								className="text-primary hover:underline"
 								onClick={() => {
-									const featuresOnly = allCols.filter(c => c !== form.target_column);
+									const featuresOnly = allCols.filter(
+										(c) => c !== form.target_column,
+									);
 									setForm({ ...form, features: featuresOnly.join(",") });
 								}}
 							>
@@ -550,7 +555,7 @@ function TrainFormFields({
 						</div>
 					)}
 				</div>
-				
+
 				{allCols.length > 0 ? (
 					<>
 						<Input
@@ -560,34 +565,44 @@ function TrainFormFields({
 							className="h-8 text-xs"
 						/>
 						<p className="text-xs text-muted-foreground mb-1">
-							Leave explicitly empty to automatically use all non-target columns.
+							Leave explicitly empty to automatically use all non-target
+							columns.
 						</p>
 						<div className="rounded-lg border bg-muted/20 p-2 max-h-40 overflow-y-auto grid grid-cols-2 gap-1">
 							{allCols
-								.filter(c => c !== form.target_column) // Can't use target as feature
-								.filter(c => featureSearch ? c.toLowerCase().includes(featureSearch.toLowerCase()) : true)
+								.filter((c) => c !== form.target_column) // Can't use target as feature
+								.filter((c) =>
+									featureSearch
+										? c.toLowerCase().includes(featureSearch.toLowerCase())
+										: true,
+								)
 								.map((col) => (
-								<label
-									key={col}
-									className="flex items-center gap-2 px-2 py-1.5 rounded-md hover:bg-muted/50 cursor-pointer text-xs"
-								>
-									<input
-										type="checkbox"
-										className="accent-primary w-3.5 h-3.5 shrink-0"
-										checked={selectedFeatures.includes(col)}
-										onChange={() => toggleFeature(col)}
-									/>
-									<span className="truncate font-mono" title={col}>
-										{col}
-									</span>
-									<Badge
-										variant="outline"
-										className={`ml-auto text-[10px] px-1 py-0 h-4 shrink-0 ${!((dtypes[col] as string)?.includes('int') || (dtypes[col] as string)?.includes('float')) ? "border-amber-500/40 text-amber-400" : "border-blue-500/40 text-blue-400"}`}
+									<label
+										key={col}
+										className="flex items-center gap-2 px-2 py-1.5 rounded-md hover:bg-muted/50 cursor-pointer text-xs"
 									>
-										{!((dtypes[col] as string)?.includes('int') || (dtypes[col] as string)?.includes('float')) ? "cat" : "num"}
-									</Badge>
-								</label>
-							))}
+										<input
+											type="checkbox"
+											className="accent-primary w-3.5 h-3.5 shrink-0"
+											checked={selectedFeatures.includes(col)}
+											onChange={() => toggleFeature(col)}
+										/>
+										<span className="truncate font-mono" title={col}>
+											{col}
+										</span>
+										<Badge
+											variant="outline"
+											className={`ml-auto text-[10px] px-1 py-0 h-4 shrink-0 ${!((dtypes[col] as string)?.includes("int") || (dtypes[col] as string)?.includes("float")) ? "border-amber-500/40 text-amber-400" : "border-blue-500/40 text-blue-400"}`}
+										>
+											{!(
+												(dtypes[col] as string)?.includes("int") ||
+												(dtypes[col] as string)?.includes("float")
+											)
+												? "cat"
+												: "num"}
+										</Badge>
+									</label>
+								))}
 						</div>
 						{selectedFeatures.length > 0 && (
 							<p className="text-xs text-primary">
@@ -597,10 +612,7 @@ function TrainFormFields({
 						)}
 					</>
 				) : (
-					<Input
-						placeholder="Select a dataset to pick features"
-						disabled
-					/>
+					<Input placeholder="Select a dataset to pick features" disabled />
 				)}
 			</div>
 
@@ -620,16 +632,16 @@ function TrainFormFields({
 					)}
 					{!isLoadingSchemas && schemas.length > 0 && (
 						<div className="pr-2 space-y-3">
-								{schemas.map((s) => (
-									<HyperparamField
-										key={s.name}
-										def={s}
-										value={hyperparams[s.name]}
-										onChange={(v) =>
-											setHyperparams({ ...hyperparams, [s.name]: v })
-										}
-									/>
-								))}
+							{schemas.map((s) => (
+								<HyperparamField
+									key={s.name}
+									def={s}
+									value={hyperparams[s.name]}
+									onChange={(v) =>
+										setHyperparams({ ...hyperparams, [s.name]: v })
+									}
+								/>
+							))}
 						</div>
 					)}
 				</div>
@@ -1044,7 +1056,8 @@ export function ModelsPage() {
 								<SheetHeader>
 									<SheetTitle>Train New Model</SheetTitle>
 									<SheetDescription>
-										Select an algorithm and map your target column to begin training.
+										Select an algorithm and map your target column to begin
+										training.
 									</SheetDescription>
 								</SheetHeader>
 							</div>
@@ -1061,11 +1074,15 @@ export function ModelsPage() {
 								/>
 							</div>
 							<div className="shrink-0 border-t p-4 bg-background flex flex-col gap-2">
-								<Button onClick={handleTrain} disabled={isTraining} className="w-full">
+								<Button
+									onClick={handleTrain}
+									disabled={isTraining}
+									className="w-full"
+								>
 									{isTraining ? (
 										<>
-											<Loader2 className="w-4 h-4 mr-2 animate-spin" />{" "}
-											Training Pipeline Active...
+											<Loader2 className="w-4 h-4 mr-2 animate-spin" /> Training
+											Pipeline Active...
 										</>
 									) : (
 										<>
@@ -1386,7 +1403,10 @@ export function ModelsPage() {
 						<SheetHeader>
 							<SheetTitle className="flex items-center gap-2">
 								<TestTube2 className="w-5 h-5" /> Test — {predictModel?.name}
-								<Badge variant="secondary" className="ml-auto text-xs font-mono">
+								<Badge
+									variant="secondary"
+									className="ml-auto text-xs font-mono"
+								>
 									{Object.keys(predictInputs).length} feature
 									{Object.keys(predictInputs).length !== 1 ? "s" : ""}
 								</Badge>
@@ -1558,7 +1578,11 @@ export function ModelsPage() {
 						/>
 					</div>
 					<div className="shrink-0 border-t p-4 bg-background flex flex-col gap-2">
-						<Button onClick={handleRetrain} disabled={isRetraining} className="w-full">
+						<Button
+							onClick={handleRetrain}
+							disabled={isRetraining}
+							className="w-full"
+						>
 							{isRetraining ? (
 								<>
 									<Loader2 className="w-4 h-4 mr-2 animate-spin" />{" "}

--- a/server/README.md
+++ b/server/README.md
@@ -126,6 +126,8 @@ All routes are prefixed with `/api`.
 | `GET` | `/api/health` | Health check + server version |
 | `POST` | `/api/auth/login` | Login, returns JWT cookie |
 | `POST` | `/api/auth/logout` | Logout, clears cookie |
+| `GET` | `/api/auth/config` | Returns `{disable_signup: bool}` (public) |
+| `POST` | `/api/auth/signup` | Register — disabled when `DISABLE_SIGNUP=True` |
 | `GET` | `/api/datasets` | List datasets |
 | `POST` | `/api/dataset/upload` | Upload a file |
 | `POST` | `/api/dataset` | Create dataset record |
@@ -157,11 +159,33 @@ uv run alembic upgrade head
 
 ## Configuration
 
-Settings are loaded from environment variables (via `pydantic_settings`). Defaults work out of the box for local development.
+Settings are loaded from environment variables (via `pydantic_settings`). Defaults work out of the box for local development. Create a `.env` file inside `server/` to override any value.
 
 | Variable | Default | Description |
 |---|---|---|
-| `APP_VERSION` | read from `pyproject.toml` | Injected by Docker build |
+| `DATABASE_URL` | `sqlite:///./mlcore_db.db` | SQLite path (override for Docker volume) |
+| `APP_ENV` | `development` | Runtime environment tag |
+| `JWT_SECRET` | `development` | **Change this in production!** |
+| `JWT_ALGORITHM` | `HS256` | JWT signing algorithm |
+| `JWT_EXPIRY` | `7` | Token lifetime in days |
+| `COOKIE_DOMAIN` | _(empty)_ | Cookie domain restriction |
+| `BCRYPT_ROUNDS` | `12` | bcrypt work factor |
+| `APP_VERSION` | read from `pyproject.toml` | Injected automatically by Docker build |
+| `DISABLE_SIGNUP` | `False` | Set `True` to disable public registration |
+| `DEFAULT_ADMIN_EMAIL` | _(none)_ | Seed an admin account on first boot |
+| `DEFAULT_ADMIN_PASSWORD` | _(none)_ | Password for the seeded admin account |
+
+### Example `.env` for a locked-down deployment
+
+```env
+JWT_SECRET=change-me-in-production
+DISABLE_SIGNUP=True
+DEFAULT_ADMIN_EMAIL=admin@yourcompany.com
+DEFAULT_ADMIN_PASSWORD=StrongP@ssw0rd!
+```
+
+When `DEFAULT_ADMIN_EMAIL` + `DEFAULT_ADMIN_PASSWORD` are set, the server automatically creates the admin user on first startup (idempotent — safe to restart).
+When `DISABLE_SIGNUP=True`, `POST /api/auth/signup` returns `403` and the client hides the Sign Up tab automatically.
 
 ---
 

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "MLCoreServer"
 description = "This is the fastapi based ml server"
 requires-python = ">=3.10"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
     # --- Backend / API ---
     "fastapi",

--- a/server/src/common/config/config.py
+++ b/server/src/common/config/config.py
@@ -18,6 +18,10 @@ class Settings(BaseSettings):
 
     # Password Hashing Settings
     BCRYPT_ROUNDS: int = 12  # Default: 12 (good balance of security/speed)
+    # Optional Default Admin Seeding
+    DEFAULT_ADMIN_EMAIL: str | None = None
+    DEFAULT_ADMIN_PASSWORD: str | None = None
+    DISABLE_SIGNUP: bool = False
 
     class Config:
         env_file = ".env"

--- a/server/src/main.py
+++ b/server/src/main.py
@@ -30,6 +30,34 @@ STATIC_DIR = Path(__file__).parent.parent / "static"
 async def lifespan(app: FastAPI):
     alembic_cfg = Config("alembic.ini")
     command.upgrade(alembic_cfg, "head")
+
+    from src.common.config.config import settings
+
+    # Check if we should seed a default admin
+    if settings.DEFAULT_ADMIN_EMAIL and settings.DEFAULT_ADMIN_PASSWORD:
+        from src.common.db.session import SessionLocal
+        from src.modules.user.schema import UserCreate
+        from src.modules.user.service import UserService
+
+        with SessionLocal() as db:
+            user_service = UserService()
+
+            # Check if user already exists
+            existing_user = user_service.get_user(
+                db=db, filters={"email": settings.DEFAULT_ADMIN_EMAIL}
+            )
+            if not existing_user:
+                logger.info(f"Seeding default admin user: {settings.DEFAULT_ADMIN_EMAIL}")
+                user_service.create_user(
+                    db=db,
+                    data=UserCreate(
+                        username="admin",
+                        email=settings.DEFAULT_ADMIN_EMAIL,
+                        password=settings.DEFAULT_ADMIN_PASSWORD,
+                        phone="0000000000",
+                    ),
+                )
+
     yield
 
 

--- a/server/src/modules/auth/router.py
+++ b/server/src/modules/auth/router.py
@@ -1,8 +1,7 @@
-from fastapi import APIRouter, Depends, Response, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Response
 from sqlalchemy.orm.session import Session
 
 from src.common.config.config import settings
-
 from src.common.db.session import get_db
 from src.modules.auth.schema import (
     AuthToken,

--- a/server/src/modules/auth/router.py
+++ b/server/src/modules/auth/router.py
@@ -1,5 +1,7 @@
-from fastapi import APIRouter, Depends, Response
+from fastapi import APIRouter, Depends, Response, HTTPException
 from sqlalchemy.orm.session import Session
+
+from src.common.config.config import settings
 
 from src.common.db.session import get_db
 from src.modules.auth.schema import (
@@ -22,10 +24,17 @@ def login(
     return auth_service.login(request=request, response=response, db=db)
 
 
+@router.get("/config")
+def get_auth_config():
+    return {"disable_signup": settings.DISABLE_SIGNUP}
+
+
 @router.post("/signup")
 def signup(
     request: SignupRequest, response: Response, db: Session = Depends(get_db)
 ) -> SignupResponse:
+    if settings.DISABLE_SIGNUP:
+        raise HTTPException(status_code=403, detail="Signup is disabled on this server instance.")
     return auth_service.signup(request=request, response=response, db=db)
 
 

--- a/server/src/modules/dataset/router.py
+++ b/server/src/modules/dataset/router.py
@@ -150,6 +150,7 @@ def get_dataset_versions(
         db=db, dataset_id=dataset_id, user_id=token_payload.id
     )
 
+
 @router.get("/dataset/{dataset_id}/data")
 def get_dataset_data(
     request: Request,

--- a/server/src/modules/dataset/router.py
+++ b/server/src/modules/dataset/router.py
@@ -149,3 +149,19 @@ def get_dataset_versions(
     return dataset_service.get_dataset_versions(
         db=db, dataset_id=dataset_id, user_id=token_payload.id
     )
+
+@router.get("/dataset/{dataset_id}/data")
+def get_dataset_data(
+    request: Request,
+    dataset_id: UUID,
+    page: int = 1,
+    limit: int = 50,
+    db: Session = Depends(get_db),
+    token_payload: AuthToken = Depends(
+        dataset_service.auth_service.security_service.verify_auth_token
+    ),
+):
+    """Return paginated rows from the dataset."""
+    return dataset_service.get_dataset_data(
+        db=db, dataset_id=dataset_id, user_id=token_payload.id, page=page, limit=limit
+    )

--- a/server/src/modules/dataset/service.py
+++ b/server/src/modules/dataset/service.py
@@ -249,7 +249,7 @@ class DatasetService:
                     IQR = Q3 - Q1
                     lower_bound = Q1 - 1.5 * IQR
                     upper_bound = Q3 + 1.5 * IQR
-                    # To avoid dropping rows with NaN in this context, use fillna(True) on the boolean mask if desired, 
+                    # To avoid dropping rows with NaN in this context, use fillna(True) on the boolean mask if desired,
                     # but typically outliers removal is fine to also drop NaNs or let them be handle elsewhere. Let's keep non-NaNs intact.
                     mask = (df[c] >= lower_bound) & (df[c] <= upper_bound)
                     df = df[mask | df[c].isna()]
@@ -284,6 +284,7 @@ class DatasetService:
             elif data.strategy == "log_transform":
                 if pd.api.types.is_numeric_dtype(df[c]):
                     import numpy as np
+
                     df[c] = np.log1p(df[c].clip(lower=0))
             elif data.strategy == "one_hot_encoder":
                 df = pd.get_dummies(df, columns=[c], dtype=int)
@@ -322,7 +323,9 @@ class DatasetService:
             "missing_percentage": (dataset.isnull().mean() * 100).round(2).to_dict(),
             "statistics": dataset.describe().to_dict(),
             "unique_values": dataset.nunique().to_dict(),
-            "correlation": dataset.select_dtypes(include='number').corr().fillna(0).to_dict() if len(dataset.select_dtypes(include='number').columns) > 1 else {},
+            "correlation": dataset.select_dtypes(include="number").corr().fillna(0).to_dict()
+            if len(dataset.select_dtypes(include="number").columns) > 1
+            else {},
             "preview": dataset.head(5).to_dict(orient="records"),
         }
 
@@ -367,23 +370,25 @@ class DatasetService:
         return dataset.corr().to_dict()
 
     @log_execution
-    def get_dataset_data(self, db: Session, dataset_id: UUID, user_id: UUID, page: int = 1, limit: int = 50):
+    def get_dataset_data(
+        self, db: Session, dataset_id: UUID, user_id: UUID, page: int = 1, limit: int = 50
+    ):
         dataset = self.get_dataset(db=db, dataset_id=dataset_id)
         if dataset.user_id != user_id:
             raise HTTPException(status_code=403, detail="Unauthorized")
-        
+
         df, file_obj, loc = self._load_dataframe(db=db, file_id=dataset.file_id)
-        
+
         total_rows = len(df)
         start_idx = (page - 1) * limit
         end_idx = start_idx + limit
-        
+
         sliced_df = df.iloc[start_idx:end_idx].fillna("")
-        
+
         return {
             "data": sliced_df.to_dict(orient="records"),
             "total_rows": total_rows,
             "page": page,
             "limit": limit,
-            "total_pages": (total_rows + limit - 1) // limit if limit > 0 else 0
+            "total_pages": (total_rows + limit - 1) // limit if limit > 0 else 0,
         }

--- a/server/src/modules/dataset/service.py
+++ b/server/src/modules/dataset/service.py
@@ -364,3 +364,25 @@ class DatasetService:
         elif file.file_type == "xlsx":
             dataset = pd.read_excel(file.location)
         return dataset.corr().to_dict()
+
+    @log_execution
+    def get_dataset_data(self, db: Session, dataset_id: UUID, user_id: UUID, page: int = 1, limit: int = 50):
+        dataset = self.get_dataset(db=db, dataset_id=dataset_id)
+        if dataset.user_id != user_id:
+            raise HTTPException(status_code=403, detail="Unauthorized")
+        
+        df, file_obj, loc = self._load_dataframe(db=db, file_id=dataset.file_id)
+        
+        total_rows = len(df)
+        start_idx = (page - 1) * limit
+        end_idx = start_idx + limit
+        
+        sliced_df = df.iloc[start_idx:end_idx].fillna("")
+        
+        return {
+            "data": sliced_df.to_dict(orient="records"),
+            "total_rows": total_rows,
+            "page": page,
+            "limit": limit,
+            "total_pages": (total_rows + limit - 1) // limit if limit > 0 else 0
+        }

--- a/server/src/modules/dataset/service.py
+++ b/server/src/modules/dataset/service.py
@@ -322,6 +322,7 @@ class DatasetService:
             "missing_percentage": (dataset.isnull().mean() * 100).round(2).to_dict(),
             "statistics": dataset.describe().to_dict(),
             "unique_values": dataset.nunique().to_dict(),
+            "correlation": dataset.select_dtypes(include='number').corr().fillna(0).to_dict() if len(dataset.select_dtypes(include='number').columns) > 1 else {},
             "preview": dataset.head(5).to_dict(orient="records"),
         }
 

--- a/server/src/modules/dataset/service.py
+++ b/server/src/modules/dataset/service.py
@@ -237,6 +237,22 @@ class DatasetService:
             elif data.strategy == "fill_median":
                 if pd.api.types.is_numeric_dtype(df[c]):
                     df[c] = df[c].fillna(df[c].median())
+            elif data.strategy == "fill_mode":
+                if not df[c].mode().empty:
+                    df[c] = df[c].fillna(df[c].mode()[0])
+            elif data.strategy == "drop_columns":
+                df = df.drop(columns=[c])
+            elif data.strategy == "remove_outliers_iqr":
+                if pd.api.types.is_numeric_dtype(df[c]):
+                    Q1 = df[c].quantile(0.25)
+                    Q3 = df[c].quantile(0.75)
+                    IQR = Q3 - Q1
+                    lower_bound = Q1 - 1.5 * IQR
+                    upper_bound = Q3 + 1.5 * IQR
+                    # To avoid dropping rows with NaN in this context, use fillna(True) on the boolean mask if desired, 
+                    # but typically outliers removal is fine to also drop NaNs or let them be handle elsewhere. Let's keep non-NaNs intact.
+                    mask = (df[c] >= lower_bound) & (df[c] <= upper_bound)
+                    df = df[mask | df[c].isna()]
 
         return self._save_new_dataset_version(db, df, dataset, user_id, "cleaned")
 
@@ -265,6 +281,12 @@ class DatasetService:
                     df[c] = MinMaxScaler().fit_transform(df[[c]])
             elif data.strategy == "label_encoder":
                 df[c] = LabelEncoder().fit_transform(df[c].astype(str))
+            elif data.strategy == "log_transform":
+                if pd.api.types.is_numeric_dtype(df[c]):
+                    import numpy as np
+                    df[c] = np.log1p(df[c].clip(lower=0))
+            elif data.strategy == "one_hot_encoder":
+                df = pd.get_dummies(df, columns=[c], dtype=int)
 
         return self._save_new_dataset_version(db, df, dataset, user_id, "transformed")
 

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -926,7 +926,7 @@ wheels = [
 
 [[package]]
 name = "mlcoreserver"
-version = "0.1.4"
+version = "0.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
This PR enhances the ML Core platform across three areas:

**Dataset Analytics UX**
Enhanced the dataset statistics sidebar to include comprehensive descriptive statistics (count, mean, std, min, 25%, 50%, 75%, max) for every numeric column, and added a Pearson correlation heatmap with colour-coded cells (green = positive, red = negative) that adapts to both light and dark modes. The backend now computes `df.corr()` and exposes it via the dataset metadata pipeline.

**Model Workflow UX**
Migrated Train, Retrain, and Predict interfaces from blocking `Dialog` overlays to persistent `Sheet` sidebars. Added a searchable checkbox grid for feature selection and refactored `PredictInputs` into a tabular list that gracefully scales to large feature counts.

**Deployment Controls**
Added three new environment variables (`DISABLE_SIGNUP`, `DEFAULT_ADMIN_EMAIL`, `DEFAULT_ADMIN_PASSWORD`) to support locked-down Docker deployments. When set, the server auto-seeds an admin user on first boot and blocks public registration at the API level. The client fetches `GET /api/auth/config` on mount and hides the Sign Up tab automatically — no client-side config needed.

Updated all three READMEs (root, server, client) to document the new features and environment variables.

Fixes # (issue)

#4 
---

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

---

## How Has This Been Tested?

1. **Dataset stats** — Uploaded a CSV with numeric columns; verified all 8 stat columns render correctly in the sidebar table.
2. **Correlation heatmap** — Verified green/red colour gradients scale with correlation magnitude; checked tooltip shows 3-decimal precision on hover; confirmed readability in both light and dark modes.
3. **DISABLE_SIGNUP** — Set `DISABLE_SIGNUP=True` in `.env`, restarted server; confirmed `POST /api/auth/signup` returns `403` and the Sign Up tab disappears from the UI on page load.
4. **Default admin seeding** — Set `DEFAULT_ADMIN_EMAIL` + `DEFAULT_ADMIN_PASSWORD`; confirmed server logs `Seeding default admin user` on first boot and skips it on subsequent restarts (idempotent).
5. **Linting** — `uv run ruff check src` → All checks passed. `npm run lint` → 0 errors, 0 warnings.

---

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules